### PR TITLE
Remove extra `get` on secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Changed
 
-- Fix issue where secrets were not correctly extracted from Experiment config [#1](https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/issues/1)
+- Fix issue where secrets were not correctly extracted from Experiment config [#1][1]
+
+[1]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/issues/1
 
 ## [0.1.2][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/chaostoolkit/chaostoolkit-reliably/compare/0.1.2...HEAD
+[Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.1.2...HEAD
+
+### Changed
+
+- Fix issue where secrets were not correctly extracted from Experiment config [#1](https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/issues/1)
 
 ## [0.1.2][]
 
-[0.1.2]: https://github.com/chaostoolkit/chaostoolkit-reliably/compare/0.1.1...0.1.2
+[0.1.2]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.1.1...0.1.2
 
 ### Changed
 
@@ -14,7 +18,7 @@
 
 ## [0.1.1][]
 
-[0.1.1]: https://github.com/chaostoolkit/chaostoolkit-reliably/compare/0.1.0...0.1.1
+[0.1.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.1.0...0.1.1
 
 ### Changed
 
@@ -22,7 +26,7 @@
 
 ## [0.1.0][]
 
-[0.1.0]: https://github.com/chaostoolkit/chaostoolkit-reliably/tree/0.1.0
+[0.1.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/tree/0.1.0
 
 ### Added
 

--- a/chaosreliably/__init__.py
+++ b/chaosreliably/__init__.py
@@ -78,9 +78,8 @@ def get_auth_info(configuration: Configuration = None,
         reliably_config_path = None
 
     secrets = secrets or {}
-    reliably_secrets = secrets.get("reliably", {})
-    reliably_token = reliably_secrets.get("token")
-    reliably_host = reliably_secrets.get("host")
+    reliably_token = secrets.get("token")
+    reliably_host = secrets.get("host")
 
     if not reliably_token and reliably_config_path:
         logger.debug("Loading Reliably config from: {}".format(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -41,10 +41,8 @@ def test_using_config_file_but_override_token_and_host():
         host, token = get_auth_info({
             "reliably_config_path": f.name
         }, {
-            "reliably": {
                 "token": "78890",
                 "host": "reliably.dev"
-            }
         })
         assert token == "78890"
         assert host == "reliably.dev"
@@ -52,10 +50,8 @@ def test_using_config_file_but_override_token_and_host():
 
 def test_using_secret_only():
     host, token = get_auth_info(None, {
-        "reliably": {
-            "token": "78890",
-            "host": "reliably.dev"
-        }
+        "token": "78890",
+        "host": "reliably.dev"
     })
     assert token == "78890"
     assert host == "reliably.dev"


### PR DESCRIPTION
# What I am changing

TL;DR: This PR fixes an issue where we were selecting `reliably` from secrets when the `reliably` key was no longer available
due to how CTK passes secrets to actions

Closes #1

# How I did it

* `chaosreliably/__init__.py`:
  * Removed `get('reliably')`
* `tests/test_auth.py`:
  * Changed test secrets to correctly represent the form they arrive in
* `CHANGELOG.md`:
  * Fix broken links  
  
# How you can test it

Setup the project for development and run `pytest`

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
