### PR TITLE
Add default of 1 to limit on get_objective_results_by_labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.0...HEAD
 
+### Changed
+
+- Updated `get_objective_results_by_labels` to have a default `limit` of `1`
+
 
 ## [0.2.0][]
 

--- a/chaosreliably/slo/probes.py
+++ b/chaosreliably/slo/probes.py
@@ -13,19 +13,27 @@ __all__ = ["get_objective_results_by_labels"]
 
 def get_objective_results_by_labels(
     labels: Dict[str, str],
-    limit: int = None,
+    limit: int = 1,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> List[Dict]:
     """
     For a given set of Objective labels, return all of the Ojective Results
+
+    :param labels: Dict[str, str] representing the Objective Labels for the Objective
+        to retrieve results for
+    :param limit: int representing how many results to retrieve - Default 1
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: List[Dict] representing the Objective Results for the given Objective
+
     """
     encoded_labels = quote(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     with get_session(configuration, secrets) as session:
         url = f"{session.reliably_url}/objectiveresult?objective-match={encoded_labels}"
-        resp = session.get(url, params={"limit": limit} if limit else None)
+        resp = session.get(url, params={"limit": limit})
         logger.debug("Fetched SLO results from: {}".format(resp.url))
         if resp.status_code != 200:
             raise ActivityFailed("Failed to retrieve SLO results: {}".format(resp.text))

--- a/chaosreliably/slo/tolerances.py
+++ b/chaosreliably/slo/tolerances.py
@@ -14,6 +14,9 @@ def all_objective_results_ok(value: List[Dict] = None) -> bool:
     remaining percent from the two is -9% and it has therefore failed.
     If an objective is set to 90% and the actual percent is 99% then the remaining
     percent is 9% and the SLO has passed.
+
+    :param value: List[Dict] representing the Objective Results to check
+    :returns: bool representing whether all the Objective Results were OK or not
     """
     not_ok_results = []
 

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -20,9 +20,9 @@ def test_that_get_objective_results_by_label_returns_correct_results(
     )
     request_url = (
         "https://api.reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
-        f"?objective-match={encoded_labels}"
+        f"?objective-match={encoded_labels}&limit=1"
     )
-    httpx_mock.add_response(method="GET", url=request_url, json=objective_results)
+    httpx_mock.add_response(method="GET", url=request_url, json=objective_results[:1])
 
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
@@ -38,7 +38,7 @@ def test_that_get_objective_results_by_label_returns_correct_results(
         results = get_objective_results_by_labels(
             labels=labels, configuration={"reliably_config_path": f.name}, secrets=None
         )
-        assert len(results) == 10
+        assert len(results) == 1
 
 
 def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_mock):
@@ -51,7 +51,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_m
     )
     request_url = (
         "https://api.reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
-        f"?objective-match={encoded_labels}"
+        f"?objective-match={encoded_labels}&limit=1"
     )
     httpx_mock.add_response(method="GET", url=request_url, status_code=400)
 


### PR DESCRIPTION
# What I am changing

TL;DR: This PR adds a default value of `1` to `get_objective_results_by_labels` and adds
some docs to the probes and tolerances to explain their parameters.

# How I did it

* `chaosreliably/slo/probes.py`:
  * Change default value from `None` to `1`
  * Flesh out docstring
* `chaosreliably/slo/tolerances.py`:
  * Flesh out docstring
* `tests/probes/test_get_objective_results.py`:
  * Updated test to reflect the default limit

# How you can test it

Get setup for development and run:

```bash
$ pytest
```

Or install the extention and then use the probe without the `limit` value

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
