### PR TITLE
Add `slo_is_met`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Updated `get_objective_results_by_labels` to have a default `limit` of `1`
+- Add `slo_is_met` as a probe to encompass the `get_objective_results_by_labels` probe and `all_objective_results_ok` tolerance
 
 
 ## [0.2.0][]

--- a/README.md
+++ b/README.md
@@ -89,20 +89,11 @@ deviated during a Chaos Toolkit experiment. Here is a simple example:
             "provider": {
                 "type": "python",
                 "module": "chaosreliably.slo.probes",
-                "func": "get_objective_results_by_labels",
+                "func": "slo_is_met",
+                "tolerance": true,
                 "arguments": {
                     "labels": {"name": "must-be-good", "service": "must-be-good-service"},
                     "limit": 5
-                }
-            },
-            "tolerance": {
-                "type": "probe",
-                "name": "Check all SLO results are ok",
-                "provider": {
-                    "type": "python",
-                    "module": "chaosreliably.slo.tolerances",
-                    "func": "all_objective_results_ok",
-                    "arguments": {}
                 }
             }
         }
@@ -138,20 +129,11 @@ mechanism to protect your system from being harmed too harshly by an experiment.
                         "provider": {
                             "type": "python",
                             "module": "chaosreliably.slo.probes",
-                            "func": "get_objective_results_by_labels",
+                            "func": "slo_is_met",
+                            "tolerance": true,
                             "arguments": {
                                 "labels": {"name": "must-be-good", "service": "must-be-good-service"},
                                 "limit": 5
-                            }
-                        },
-                        "tolerance": {
-                            "type": "probe",
-                            "name": "Check all SLO results are ok",
-                            "provider": {
-                                "type": "python",
-                                "module": "chaosreliably.slo.tolerances",
-                                "func": "all_objective_results_ok",
-                                "arguments": {}
                             }
                         }
                     }

--- a/chaosreliably/slo/probes.py
+++ b/chaosreliably/slo/probes.py
@@ -8,7 +8,9 @@ from logzero import logger
 
 from chaosreliably import get_session
 
-__all__ = ["get_objective_results_by_labels"]
+from .tolerances import all_objective_results_ok
+
+__all__ = ["get_objective_results_by_labels", "slo_is_met"]
 
 
 def get_objective_results_by_labels(
@@ -38,3 +40,25 @@ def get_objective_results_by_labels(
         if resp.status_code != 200:
             raise ActivityFailed("Failed to retrieve SLO results: {}".format(resp.text))
         return resp.json()
+
+
+def slo_is_met(
+    labels: Dict[str, str],
+    limit: int = 1,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
+    """
+    For a given set of Objective labels, return whether the Objective was met
+
+    :param labels: Dict[str, str] representing the Objective Labels for the Objective
+        to retrieve results for
+    :param limit: int representing how many results to retrieve - Default 1
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: bool representing whether the SLO was met or not
+    """
+    results = get_objective_results_by_labels(
+        labels=labels, limit=limit, configuration=configuration, secrets=secrets
+    )
+    return all_objective_results_ok(results)

--- a/tests/probes/test_slo_is_met.py
+++ b/tests/probes/test_slo_is_met.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from chaosreliably.slo.probes import slo_is_met
+
+
+@patch("chaosreliably.slo.probes.all_objective_results_ok")
+@patch("chaosreliably.slo.probes.get_objective_results_by_labels")
+def test_that_slo_is_met_correctly_calls_probe_and_tolerance_with_no_limit(
+    mock_get_objective_results_by_labels, mock_all_objective_results_ok
+):
+    expected_results = [{"objective_result": "a-result"}]
+    mock_get_objective_results_by_labels.return_value = expected_results
+    mock_all_objective_results_ok.return_value = True
+    expected_labels = {"a-label": "a-label-value"}
+
+    slo_is_met_result = slo_is_met(labels=expected_labels, limit=1)
+
+    mock_get_objective_results_by_labels.assert_called_once_with(
+        limit=1, labels=expected_labels, configuration=None, secrets=None
+    )
+    mock_all_objective_results_ok.assert_called_once_with(expected_results)
+
+    assert slo_is_met_result
+
+
+@patch("chaosreliably.slo.probes.all_objective_results_ok")
+@patch("chaosreliably.slo.probes.get_objective_results_by_labels")
+def test_that_slo_is_met_correctly_calls_probe_and_tolerance_with_limit(
+    mock_get_objective_results_by_labels, mock_all_objective_results_ok
+):
+    expected_results = [{"objective_result": "a-result"}]
+    mock_get_objective_results_by_labels.return_value = expected_results
+    mock_all_objective_results_ok.return_value = False
+    expected_labels = {"a-label": "a-label-value"}
+
+    slo_is_met_result = slo_is_met(labels=expected_labels, limit=10)
+
+    mock_get_objective_results_by_labels.assert_called_once_with(
+        limit=10, labels=expected_labels, configuration=None, secrets=None
+    )
+    mock_all_objective_results_ok.assert_called_once_with(expected_results)
+
+    assert not slo_is_met_result


### PR DESCRIPTION
# What I am changing

TL;DR: This PR adds the `slo_is_met` probe to encapsulate `get_all_objective_results_by_labels` and `all_objective_results_ok`.

# How I did it

* `chaosreliably/slo/probes.py`:
  * Add `slo_is_met`
* `tests/probes/test_slo_is_met.py`:
  * Add tests to ensure the wrapper calls the probe and tolerance correctly
* Update CHANGELOG.md
* Update README.md

# How you can test it

Get setup for development and run:

```bash
$ pytest
```

Or get setup with Reliably and use the new probe as your Steady State Hypothesis:

```json
"steady-state-hypothesis": {
    "title": "We do not consume all of our error budgets during the experiment",
    "probes": [
        {
            "name": "Our 'Must be good' SLO results must be OK",
            "type": "probe",
            "provider": {
                "type": "python",
                "module": "chaosreliably.slo.probes",
                "func": "slo_is_met",
                "tolerance": true,
                "arguments": {
                    "labels": {"name": "must-be-good", "service": "must-be-good-service"},
                    "limit": 5
                }
            }
        }
    ]
}
```
Signed-off-by: Ciaran Evans <ciaran@reliably.com>