### PR TITLE
Fix README.md examples for slo_is_met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.1...HEAD
 
+- Updated `README.md` to correctly show where `tolerance` goes when using `slo_is_met` as a Steady State Hypothesis
+
 ## [0.2.1][]
 
 [0.2.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.0...0.2.1

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ deviated during a Chaos Toolkit experiment. Here is a simple example:
                 "type": "python",
                 "module": "chaosreliably.slo.probes",
                 "func": "slo_is_met",
-                "tolerance": true,
                 "arguments": {
                     "labels": {"name": "must-be-good", "service": "must-be-good-service"},
                     "limit": 5
                 }
-            }
+            },
+            "tolerance": true,
         }
     ]
 }
@@ -130,12 +130,12 @@ mechanism to protect your system from being harmed too harshly by an experiment.
                             "type": "python",
                             "module": "chaosreliably.slo.probes",
                             "func": "slo_is_met",
-                            "tolerance": true,
                             "arguments": {
                                 "labels": {"name": "must-be-good", "service": "must-be-good-service"},
                                 "limit": 5
                             }
-                        }
+                        },
+                        "tolerance": true
                     }
                 ]
             }


### PR DESCRIPTION
The `tolerance` blocks for `slo_is_met` in Steady State Hypothesis blocks was incorrect

Signed-off-by: Ciaran Evans <ciaran@reliably.com>