### PR TITLE
Fixing default reliably host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.1...HEAD
 
 - Updated `README.md` to correctly show where `tolerance` goes when using `slo_is_met` as a Steady State Hypothesis
+- Fixed default reliably host to be `reliably.com` instead of `api.reliably.com`
 
 ## [0.2.1][]
 

--- a/chaosreliably/__init__.py
+++ b/chaosreliably/__init__.py
@@ -13,7 +13,7 @@ from logzero import logger
 __version__ = "0.2.1"
 __all__ = ["get_session", "discover"]
 RELIABLY_CONFIG_PATH = "~/.config/reliably/config.yaml"
-RELIABLY_HOST = "api.reliably.com"
+RELIABLY_HOST = "reliably.com"
 
 
 @contextmanager

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -59,9 +59,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_m
         with NamedTemporaryFile(mode="w") as f:
             yaml.safe_dump(
                 {
-                    "auths": {
-                        "reliably.com": {"token": "12345", "username": "jane"}
-                    },
+                    "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
                     "currentOrg": {"name": "test-org"},
                 },
                 f,

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -19,7 +19,7 @@ def test_that_get_objective_results_by_label_returns_correct_results(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://api.reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=1"
     )
     httpx_mock.add_response(method="GET", url=request_url, json=objective_results[:1])
@@ -27,7 +27,7 @@ def test_that_get_objective_results_by_label_returns_correct_results(
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
             {
-                "auths": {"api.reliably.com": {"token": "12345", "username": "jane"}},
+                "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
                 "currentOrg": {"name": "test-org"},
             },
             f,
@@ -50,7 +50,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_m
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://api.reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=1"
     )
     httpx_mock.add_response(method="GET", url=request_url, status_code=400)
@@ -60,7 +60,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_m
             yaml.safe_dump(
                 {
                     "auths": {
-                        "api.reliably.com": {"token": "12345", "username": "jane"}
+                        "reliably.com": {"token": "12345", "username": "jane"}
                     },
                     "currentOrg": {"name": "test-org"},
                 },
@@ -87,7 +87,7 @@ def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://api.reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=20"
     )
     httpx_mock.add_response(method="GET", url=request_url, json=objective_results)
@@ -95,7 +95,7 @@ def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
             {
-                "auths": {"api.reliably.com": {"token": "12345", "username": "jane"}},
+                "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
                 "currentOrg": {"name": "test-org"},
             },
             f,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,7 @@ def test_using_config_file():
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
             {
-                "auths": {"api.reliably.com": {"token": "12345", "username": "jane"}},
+                "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
                 "currentOrg": {"name": "test-org"},
             },
             f,
@@ -22,7 +22,7 @@ def test_using_config_file():
 
         auth_info = get_auth_info({"reliably_config_path": f.name})
         assert auth_info["token"] == "12345"
-        assert auth_info["host"] == "api.reliably.com"
+        assert auth_info["host"] == "reliably.com"
         assert auth_info["org"] == "test-org"
 
 


### PR DESCRIPTION
Fixed default reliably host to be `reliably.com` instead of `api.reliably.com`

Signed-off-by: Charlie Moon <charlie@chaosiq.io>