### PR TITLE
Bring `build.yaml` and `Makefile` up to how `chaostoolkit` does it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,42 @@
-name: Build
+name: Build, Test, and Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+    - name: Build the chaostoolkit package
+      run : |
+        make build
+
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        make install-dev
+    - name: Lint chaostoolkit
+      run: |
+        make lint
+
   test:
     runs-on: ubuntu-20.04
     strategy:
@@ -11,32 +45,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt -r requirements-dev.txt
-    - name: Checking the code syntax
-      run: |
-        make lint
+        make install-dev
     - name: Run tests
       run: |
-        pip install -e .
-        pytest tests/
-
-  build:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.6'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-    - name: Build the package
-      run : |
-        python3 setup.py build
+        make tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.2...HEAD
 
+### Changed
+
+- Updated `.github/workflows/build.yaml` to be in line with `chaostoolkit`
+- Updated `Makefile` to be in line with `chaostoolkit`
+
 ## [0.2.2][]
 
 [0.2.2]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.1...0.2.2

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,28 @@
+.PHONY: install
+install:
+	pip install --upgrade pip setuptools wheel
+	pip install -r requirements.txt
+
+.PHONY: install-dev
+install-dev: install
+	pip install -r requirements-dev.txt
+	python setup.py develop
+
+.PHONY: build
+build:
+	python setup.py build
+
 .PHONY: lint
 lint:
-	flake8 chaosreliably/ tests/ examples/
-	isort --check-only --profile black chaosreliably/ tests/ examples/
-	black --check --diff chaosreliably/ tests/ examples/
+	flake8 chaosreliably/ tests/
+	isort --check-only --profile black chaosreliably/ tests/
+	black --check --diff chaosreliably/ tests/
 
 .PHONY: format
 format:
-	isort --profile black chaosreliably/ tests/ examples/
-	black chaosreliably/ tests/ examples/
+	isort --profile black chaosreliably/ tests/
+	black chaosreliably/ tests/
+
+.PHONY: tests
+tests:
+	pytest


### PR DESCRIPTION
This PR is some cub-scout'ing of the `build.yaml` and `Makefile` to be more in line
with `chaostoolkit`
