### PR TITLE
Cover off missing tests for getting auth info and discovering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `check-pr.md` which alerts PR raisers to whether they've modified
 `CHANGELOG.md` or tests.
 - Ran `pyupgrade --py36-plus` on the project
+- Bump up coverage in tests to cover failure cases in `__init__.py`
 
 ## [0.2.2][]
 

--- a/chaosreliably/__init__.py
+++ b/chaosreliably/__init__.py
@@ -98,7 +98,7 @@ def get_auth_info(
     ):
         raise ActivityFailed(
             "Make sure to login against Reliably's services and/or provide "
-            "them correct authentication information to the experiment."
+            "the correct authentication information to the experiment."
         )
 
     if not reliably_token:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,15 @@
+from chaosreliably import __version__, discover
+
+
+def test_that_discover_returns_correct_discovery():
+    discovery = discover()
+    assert discovery["extension"]["name"] == "chaostoolkit-reliably"
+    assert discovery["extension"]["version"] == __version__
+    names = [activity["name"] for activity in discovery["activities"]]
+    assert len(names) == 3
+    for name in [
+        "get_objective_results_by_labels",
+        "slo_is_met",
+        "all_objective_results_ok",
+    ]:
+        assert name in names


### PR DESCRIPTION
This PR adds some extra coverage to the tests as we were missing a few error cases
which would have been a pain to debug otherwise

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
