### PR TITLE
Add `mypy` and required typing changes because of it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-    - name: Build the chaostoolkit package
+    - name: Build the chaosreliably package
       run : |
         make build
 
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         make install-dev
-    - name: Lint chaostoolkit
+    - name: Lint chaosreliably
       run: |
         make lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 `CHANGELOG.md` or tests.
 - Ran `pyupgrade --py36-plus` on the project
 - Bump up coverage in tests to cover failure cases in `__init__.py`
+- Add `mypy` as a dependency and use it in linting to enforce typing
 
 ## [0.2.2][]
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ lint:
 	flake8 chaosreliably/ tests/
 	isort --check-only --profile black chaosreliably/ tests/
 	black --check --diff chaosreliably/ tests/
+	mypy chaosreliably/ tests/
 
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If you wish to develop on this project, make sure to install the development
 dependencies. But first, [create a virtual environment][venv] and then install
 those dependencies.
 
-[venv]: http://docs.chaostoolkit.org/reference/usage/install/#create-a-virtual-environment
+[venv]: http://chaostoolkit.org/reference/usage/install/#create-a-virtual-environment
 
 ```console
 $ make install-dev

--- a/README.md
+++ b/README.md
@@ -151,12 +151,21 @@ once every minute or less).
 
 ## Contribute
 
-If you wish to contribute more functions to this package, you are more than
-welcome to do so. Please, fork this project, make your changes following the
-usual [PEP 8][pep8] code style, sprinkling with tests and submit a PR for
-review.
+From a code perspective, if you wish to contribute, you will need to run a
+Python 3.6+ environment. Please, fork this project, write unit tests to cover
+the proposed changes, implement the changes, ensure they meet the formatting
+standards set out by `black`, `flake8`, `isort`, and `mypy`, add an entry into
+`CHANGELOG.md`, and then raise a PR to the repository for review
 
-[pep8]: https://pycodestyle.readthedocs.io/en/latest/
+Please refer to the [formatting](#formatting-and-linting) section for more
+information on the formatting standards.
+
+The Chaos Toolkit projects require all contributors must sign a
+[Developer Certificate of Origin][dco] on each commit they would like to merge
+into the master branch of the repository. Please, make sure you can abide by
+the rules of the DCO before submitting a PR.
+
+[dco]: https://github.com/probot/dco#how-it-works
 
 ### Develop
 
@@ -164,41 +173,45 @@ If you wish to develop on this project, make sure to install the development
 dependencies. But first, [create a virtual environment][venv] and then install
 those dependencies.
 
-[venv]: http://chaostoolkit.org/reference/usage/install/#create-a-virtual-environment
+[venv]: http://docs.chaostoolkit.org/reference/usage/install/#create-a-virtual-environment
 
 ```console
-$ pip install -r requirements-dev.txt -r requirements.txt 
+$ make install-dev
 ```
-
-Then, point your environment to this directory:
-
-```console
-$ python setup.py develop
-```
-
-Now, you can edit the files and they will be automatically be seen by your
-environment, even when running from the `chaos` command locally.
 
 ### Test
 
 To run the tests for the project execute the following:
 
+```console
+$ make tests
 ```
-$ pytest
+
+### Formatting and Linting
+
+We use a combination of [`black`][black], [`flake8`][flake8], [`isort`][isort],
+and [`mypy`][mypy] to both lint and format this repositories code.
+
+[black]: https://github.com/psf/black
+[flake8]: https://github.com/PyCQA/flake8
+[isort]: https://github.com/PyCQA/isort
+[mypy]: https://github.com/python/mypy
+
+Before raising a Pull Request, we recommend you run formatting against your
+code with:
+
+```console
+$ make format
 ```
 
-### Linting & Formatting
+This will automatically format any code that doesn't adhere to the formatting
+standards.
 
-A `Makefile` is provided to abstract away the linting and formatting commands.
+As some things are not picked up by the formatting, we also recommend you run:
 
-To lint the project, run:
-
-```bash
+```console
 $ make lint
 ```
 
-To format the project, run:
-
-```bash
-$ make format
-```
+To ensure that any unused import statements/strings that are too long, etc.
+are also picked up. It will also provide you with any errors `mypy` picks up.

--- a/chaosreliably/__init__.py
+++ b/chaosreliably/__init__.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import contextmanager
-from typing import Dict, List
+from typing import Dict, Generator, List
 
 import httpx
 import yaml
@@ -18,15 +18,15 @@ RELIABLY_HOST = "reliably.com"
 @contextmanager
 def get_session(
     configuration: Configuration = None, secrets: Secrets = None
-) -> httpx.Client:
+) -> Generator[httpx.Client, None, None]:
     auth_info = get_auth_info(configuration, secrets)
     headers = {
         "Content-Type": "application/json",
         "Authorization": "Bearer {}".format(auth_info["token"]),
     }
     with httpx.Client() as client:
-        client.headers = headers
-        client.reliably_url = (
+        client.headers = httpx.Headers(headers)
+        client.base_url = httpx.URL(
             f"https://{auth_info['host']}/entities/{auth_info['org']}/reliably.com/v1"
         )
         yield client

--- a/chaosreliably/slo/probes.py
+++ b/chaosreliably/slo/probes.py
@@ -6,7 +6,7 @@ from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
 from chaosreliably import get_session
-from chaosreliably.types import ApiObjectiveResult
+from chaosreliably.types import ObjectiveResult
 
 from .tolerances import all_objective_results_ok
 
@@ -18,7 +18,7 @@ def get_objective_results_by_labels(
     limit: int = 1,
     configuration: Configuration = None,
     secrets: Secrets = None,
-) -> List[ApiObjectiveResult]:
+) -> List[ObjectiveResult]:
     """
     For a given set of Objective labels, return all of the Ojective Results
 
@@ -39,7 +39,7 @@ def get_objective_results_by_labels(
         logger.debug(f"Fetched SLO results from: {resp.url}")
         if resp.status_code != 200:
             raise ActivityFailed(f"Failed to retrieve SLO results: {resp.text}")
-        return ApiObjectiveResult.parse_list(resp.json())
+        return ObjectiveResult.parse_list(resp.json())
 
 
 def slo_is_met(

--- a/chaosreliably/slo/probes.py
+++ b/chaosreliably/slo/probes.py
@@ -27,7 +27,8 @@ def get_objective_results_by_labels(
     :param limit: int representing how many results to retrieve - Default 1
     :param configuration: Configuration object provided by Chaos Toolkit
     :param secrets: Secret object provided by Chaos Toolkit
-    :returns: List[Dict] representing the Objective Results for the given Objective
+    :returns: List[ObjectiveResult] representing the Objective Results for the given
+        Objective
 
     """
     encoded_labels = quote(

--- a/chaosreliably/slo/probes.py
+++ b/chaosreliably/slo/probes.py
@@ -6,6 +6,7 @@ from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
 from chaosreliably import get_session
+from chaosreliably.types import ApiObjectiveResult
 
 from .tolerances import all_objective_results_ok
 
@@ -17,7 +18,7 @@ def get_objective_results_by_labels(
     limit: int = 1,
     configuration: Configuration = None,
     secrets: Secrets = None,
-) -> List[Dict]:
+) -> List[ApiObjectiveResult]:
     """
     For a given set of Objective labels, return all of the Ojective Results
 
@@ -33,12 +34,12 @@ def get_objective_results_by_labels(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     with get_session(configuration, secrets) as session:
-        url = f"{session.reliably_url}/objectiveresult?objective-match={encoded_labels}"
+        url = f"/objectiveresult?objective-match={encoded_labels}"
         resp = session.get(url, params={"limit": limit})
         logger.debug(f"Fetched SLO results from: {resp.url}")
         if resp.status_code != 200:
             raise ActivityFailed(f"Failed to retrieve SLO results: {resp.text}")
-        return resp.json()
+        return ApiObjectiveResult.parse_list(resp.json())
 
 
 def slo_is_met(

--- a/chaosreliably/slo/tolerances.py
+++ b/chaosreliably/slo/tolerances.py
@@ -3,12 +3,12 @@ from typing import List
 from logzero import logger
 from tabulate import tabulate
 
-from chaosreliably.types import ApiObjectiveResult
+from chaosreliably.types import ObjectiveResult
 
 __all__ = ["all_objective_results_ok"]
 
 
-def all_objective_results_ok(value: List[ApiObjectiveResult]) -> bool:
+def all_objective_results_ok(value: List[ObjectiveResult]) -> bool:
     """
     Determines if any of the objective results provided had a `remainingPercent` of less
     than 0. This means the SLO failed:

--- a/chaosreliably/slo/tolerances.py
+++ b/chaosreliably/slo/tolerances.py
@@ -17,7 +17,7 @@ def all_objective_results_ok(value: List[ObjectiveResult]) -> bool:
     If an objective is set to 90% and the actual percent is 99% then the remaining
     percent is 9% and the SLO has passed.
 
-    :param value: List[Dict] representing the Objective Results to check
+    :param value: List[ObjectiveResult] representing the Objective Results to check
     :returns: bool representing whether all the Objective Results were OK or not
     """
     not_ok_results = []

--- a/chaosreliably/slo/tolerances.py
+++ b/chaosreliably/slo/tolerances.py
@@ -1,12 +1,14 @@
-from typing import Dict, List
+from typing import List
 
 from logzero import logger
 from tabulate import tabulate
 
+from chaosreliably.types import ApiObjectiveResult
+
 __all__ = ["all_objective_results_ok"]
 
 
-def all_objective_results_ok(value: List[Dict] = None) -> bool:
+def all_objective_results_ok(value: List[ApiObjectiveResult]) -> bool:
     """
     Determines if any of the objective results provided had a `remainingPercent` of less
     than 0. This means the SLO failed:
@@ -21,15 +23,15 @@ def all_objective_results_ok(value: List[Dict] = None) -> bool:
     not_ok_results = []
 
     for result in value:
-        if result["spec"]["remainingPercent"] < 0:
+        if result.spec.remaining_percent < 0:
             not_ok_results.append(
                 [
-                    result["metadata"]["labels"]["from"],
-                    result["metadata"]["labels"]["to"],
-                    result["spec"]["objectivePercent"],
-                    result["spec"]["actualPercent"],
-                    result["spec"]["remainingPercent"],
-                    result["spec"]["indicatorSelector"],
+                    result.metadata.labels["from"],
+                    result.metadata.labels["to"],
+                    result.spec.objective_percent,
+                    result.spec.actual_percent,
+                    result.spec.remaining_percent,
+                    result.spec.indicator_selector,
                 ]
             )
 

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List
 
 from pydantic import BaseModel, Field, parse_obj_as
@@ -21,5 +19,5 @@ class ObjectiveResult(BaseModel):
     metadata: ObjectiveResultMetadata
     spec: ObjectiveResultSpec
 
-    def parse_list(obj: Any) -> List[ObjectiveResult]:
+    def parse_list(obj: Any) -> "List[ObjectiveResult]":
         return parse_obj_as(List[ObjectiveResult], obj)

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -5,21 +5,21 @@ from typing import Any, Dict, List
 from pydantic import BaseModel, Field, parse_obj_as
 
 
-class ApiObjectiveResultMetadata(BaseModel):
+class ObjectiveResultMetadata(BaseModel):
     labels: Dict[str, str]
     related_to: List[Dict[str, str]] = Field(alias="relatedTo", default=None)
 
 
-class ApiObjectiveResultSpec(BaseModel):
+class ObjectiveResultSpec(BaseModel):
     indicator_selector: Dict[str, str] = Field(alias="indicatorSelector")
     objective_percent: float = Field(alias="objectivePercent")
     actual_percent: float = Field(alias="actualPercent")
     remaining_percent: float = Field(alias="remainingPercent")
 
 
-class ApiObjectiveResult(BaseModel):
-    metadata: ApiObjectiveResultMetadata
-    spec: ApiObjectiveResultSpec
+class ObjectiveResult(BaseModel):
+    metadata: ObjectiveResultMetadata
+    spec: ObjectiveResultSpec
 
-    def parse_list(obj: Any) -> List[ApiObjectiveResult]:
-        return parse_obj_as(List[ApiObjectiveResult], obj)
+    def parse_list(obj: Any) -> List[ObjectiveResult]:
+        return parse_obj_as(List[ObjectiveResult], obj)

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field, parse_obj_as
+
+
+class ApiObjectiveResultMetadata(BaseModel):
+    labels: Dict[str, str]
+    related_to: List[Dict[str, str]] = Field(alias="relatedTo", default=None)
+
+
+class ApiObjectiveResultSpec(BaseModel):
+    indicator_selector: Dict[str, str] = Field(alias="indicatorSelector")
+    objective_percent: float = Field(alias="objectivePercent")
+    actual_percent: float = Field(alias="actualPercent")
+    remaining_percent: float = Field(alias="remainingPercent")
+
+
+class ApiObjectiveResult(BaseModel):
+    metadata: ApiObjectiveResultMetadata
+    spec: ApiObjectiveResultSpec
+
+    def parse_list(obj: Any) -> List[ApiObjectiveResult]:
+        return parse_obj_as(List[ApiObjectiveResult], obj)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+strict = True
+
+[mypy-chaoslib.*]
+ignore_missing_imports = True
+
+[mypy-logzero]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,10 @@ coverage
 black
 flake8
 isort
+mypy
 pytest>=6.0
 pytest-cov
 pytest-sugar
 pytest-httpx
+types-PyYAML
+types-tabulate

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ setup_requires =
 install_requires =
     chaostoolkit-lib>=1.19.0
     logzero
-    requests
     httpx
     pyyaml~=5.4
     pydantic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,19 @@
 import json
 import os
+from copy import deepcopy
 from pathlib import Path
+from typing import Any, List
 
 from pytest import fixture
 from tabulate import tabulate
+
+from chaosreliably.types import ApiObjectiveResult
 
 TEST_DATA_DIR = os.path.join(Path(__file__).parent, "data")
 
 
 @fixture
-def objective_results():
+def results() -> Any:
     with open(
         os.path.join(TEST_DATA_DIR, "objective_results_from_api.json")
     ) as json_in:
@@ -17,16 +21,23 @@ def objective_results():
 
 
 @fixture
-def objective_results_all_ok(objective_results):
-    for result in objective_results:
-        result["spec"]["objectivePercent"] = 90.00
-        result["spec"]["actualPercent"] = 100.00
-        result["spec"]["remainingPercent"] = 10.00
-    return objective_results
+def objective_results_not_all_ok(results: Any) -> List[ApiObjectiveResult]:
+    results_not_all_okay = deepcopy(results)
+    return ApiObjectiveResult.parse_list(results_not_all_okay)
 
 
 @fixture
-def not_ok_table_contents():
+def objective_results_all_ok(results: Any) -> List[ApiObjectiveResult]:
+    results_all_okay = deepcopy(results)
+    for result in results_all_okay:
+        result["spec"]["objectivePercent"] = 90.00
+        result["spec"]["actualPercent"] = 100.00
+        result["spec"]["remainingPercent"] = 10.00
+    return ApiObjectiveResult.parse_list(results_all_okay)
+
+
+@fixture
+def not_ok_table_contents() -> Any:
     return [
         [
             "2021-07-22 10:51:55.184558 +0000 UTC",
@@ -71,7 +82,7 @@ def not_ok_table_contents():
 
 
 @fixture
-def not_ok_table(not_ok_table_contents):
+def not_ok_table(not_ok_table_contents: Any) -> str:
     headers = [
         "From",
         "To",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Any, List
 from pytest import fixture
 from tabulate import tabulate
 
-from chaosreliably.types import ApiObjectiveResult
+from chaosreliably.types import ObjectiveResult
 
 TEST_DATA_DIR = os.path.join(Path(__file__).parent, "data")
 
@@ -21,19 +21,19 @@ def results() -> Any:
 
 
 @fixture
-def objective_results_not_all_ok(results: Any) -> List[ApiObjectiveResult]:
+def objective_results_not_all_ok(results: Any) -> List[ObjectiveResult]:
     results_not_all_okay = deepcopy(results)
-    return ApiObjectiveResult.parse_list(results_not_all_okay)
+    return ObjectiveResult.parse_list(results_not_all_okay)
 
 
 @fixture
-def objective_results_all_ok(results: Any) -> List[ApiObjectiveResult]:
+def objective_results_all_ok(results: Any) -> List[ObjectiveResult]:
     results_all_okay = deepcopy(results)
     for result in results_all_okay:
         result["spec"]["objectivePercent"] = 90.00
         result["spec"]["actualPercent"] = 100.00
         result["spec"]["remainingPercent"] = 10.00
-    return ApiObjectiveResult.parse_list(results_all_okay)
+    return ObjectiveResult.parse_list(results_all_okay)
 
 
 @fixture

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -106,10 +106,10 @@ def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
             default_flow_style=False,
         )
         f.seek(0)
-        results = get_objective_results_by_labels(
+        res = get_objective_results_by_labels(
             labels=labels,
             limit=20,
             configuration={"reliably_config_path": f.name},
             secrets=None,
         )
-        assert len(results) == 10
+        assert len(res) == 10

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -8,7 +8,7 @@ import yaml
 from chaoslib.exceptions import ActivityFailed
 
 from chaosreliably.slo.probes import get_objective_results_by_labels
-from chaosreliably.types import ApiObjectiveResult
+from chaosreliably.types import ObjectiveResult
 
 
 def test_that_get_objective_results_by_label_returns_correct_results(
@@ -80,7 +80,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(
 
 
 def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
-    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: List[ApiObjectiveResult]
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: List[ObjectiveResult]
 ) -> None:
     labels = {
         "name": "exploring-reliability-guide",

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -1,16 +1,19 @@
 from tempfile import NamedTemporaryFile
+from typing import Any, List
 from urllib.parse import quote
 
 import pytest
+import pytest_httpx
 import yaml
 from chaoslib.exceptions import ActivityFailed
 
 from chaosreliably.slo.probes import get_objective_results_by_labels
+from chaosreliably.types import ApiObjectiveResult
 
 
 def test_that_get_objective_results_by_label_returns_correct_results(
-    httpx_mock, objective_results
-):
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: Any
+) -> None:
     labels = {
         "name": "exploring-reliability-guide",
         "service": "exploring-reliability-guide-service",
@@ -22,7 +25,7 @@ def test_that_get_objective_results_by_label_returns_correct_results(
         "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=1"
     )
-    httpx_mock.add_response(method="GET", url=request_url, json=objective_results[:1])
+    httpx_mock.add_response(method="GET", url=request_url, json=results[:1])
 
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
@@ -35,13 +38,15 @@ def test_that_get_objective_results_by_label_returns_correct_results(
             default_flow_style=False,
         )
         f.seek(0)
-        results = get_objective_results_by_labels(
+        res = get_objective_results_by_labels(
             labels=labels, configuration={"reliably_config_path": f.name}, secrets=None
         )
-        assert len(results) == 1
+        assert len(res) == 1
 
 
-def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_mock):
+def test_that_get_objective_results_by_label_raises_exception_if_non_200(
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock,
+) -> None:
     labels = {
         "name": "exploring-reliability-guide",
         "service": "exploring-reliability-guide-service",
@@ -75,8 +80,8 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(httpx_m
 
 
 def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
-    httpx_mock, objective_results
-):
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: List[ApiObjectiveResult]
+) -> None:
     labels = {
         "name": "exploring-reliability-guide",
         "service": "exploring-reliability-guide-service",
@@ -88,7 +93,7 @@ def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
         "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=20"
     )
-    httpx_mock.add_response(method="GET", url=request_url, json=objective_results)
+    httpx_mock.add_response(method="GET", url=request_url, json=results)
 
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(

--- a/tests/probes/test_slo_is_met.py
+++ b/tests/probes/test_slo_is_met.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from chaosreliably.slo.probes import slo_is_met
 
@@ -6,8 +6,9 @@ from chaosreliably.slo.probes import slo_is_met
 @patch("chaosreliably.slo.probes.all_objective_results_ok")
 @patch("chaosreliably.slo.probes.get_objective_results_by_labels")
 def test_that_slo_is_met_correctly_calls_probe_and_tolerance_with_no_limit(
-    mock_get_objective_results_by_labels, mock_all_objective_results_ok
-):
+    mock_get_objective_results_by_labels: MagicMock,
+    mock_all_objective_results_ok: MagicMock,
+) -> None:
     expected_results = [{"objective_result": "a-result"}]
     mock_get_objective_results_by_labels.return_value = expected_results
     mock_all_objective_results_ok.return_value = True
@@ -26,8 +27,9 @@ def test_that_slo_is_met_correctly_calls_probe_and_tolerance_with_no_limit(
 @patch("chaosreliably.slo.probes.all_objective_results_ok")
 @patch("chaosreliably.slo.probes.get_objective_results_by_labels")
 def test_that_slo_is_met_correctly_calls_probe_and_tolerance_with_limit(
-    mock_get_objective_results_by_labels, mock_all_objective_results_ok
-):
+    mock_get_objective_results_by_labels: MagicMock,
+    mock_all_objective_results_ok: MagicMock,
+) -> None:
     expected_results = [{"objective_result": "a-result"}]
     mock_get_objective_results_by_labels.return_value = expected_results
     mock_all_objective_results_ok.return_value = False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,6 @@
 import uuid
 from tempfile import NamedTemporaryFile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -10,7 +10,7 @@ from yaml.error import YAMLError
 from chaosreliably import get_auth_info
 
 
-def test_using_config_file():
+def test_using_config_file() -> None:
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
             {
@@ -30,7 +30,7 @@ def test_using_config_file():
 
 
 @patch("chaosreliably.yaml.safe_load")
-def test_invalid_yaml_file_errors(mock_safe_load):
+def test_invalid_yaml_file_errors(mock_safe_load: MagicMock) -> None:
     mock_safe_load.side_effect = YAMLError("An Error")
     with NamedTemporaryFile(mode="w") as f:
         f.write("")
@@ -42,7 +42,7 @@ def test_invalid_yaml_file_errors(mock_safe_load):
     )
 
 
-def test_using_config_file_but_override_token_and_host():
+def test_using_config_file_but_override_token_and_host() -> None:
     with NamedTemporaryFile(mode="w") as f:
         yaml.safe_dump(
             {
@@ -64,7 +64,7 @@ def test_using_config_file_but_override_token_and_host():
         assert auth_info["org"] == "overriden-org"
 
 
-def test_using_secret_only():
+def test_using_secret_only() -> None:
     auth_info = get_auth_info(
         None, {"token": "78890", "host": "reliably.dev", "org": "secret-org"}
     )
@@ -73,7 +73,7 @@ def test_using_secret_only():
     assert auth_info["org"] == "secret-org"
 
 
-def test_missing_token_from_secrets():
+def test_missing_token_from_secrets() -> None:
     with pytest.raises(ActivityFailed) as ex:
         get_auth_info(
             {
@@ -87,7 +87,7 @@ def test_missing_token_from_secrets():
     )
 
 
-def test_missing_host_from_secrets():
+def test_missing_host_from_secrets() -> None:
     with pytest.raises(ActivityFailed) as ex:
         get_auth_info(
             {
@@ -101,7 +101,7 @@ def test_missing_host_from_secrets():
     )
 
 
-def test_missing_org_from_secrets():
+def test_missing_org_from_secrets() -> None:
     with pytest.raises(ActivityFailed) as ex:
         get_auth_info(
             {
@@ -115,7 +115,7 @@ def test_missing_org_from_secrets():
     )
 
 
-def test_no_config_at_path_and_no_secrets_provided():
+def test_no_config_at_path_and_no_secrets_provided() -> None:
     with pytest.raises(ActivityFailed) as ex:
         get_auth_info({"reliably_config_path": str(uuid.uuid4())}, None)
     assert str(ex.value) == (

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,7 +1,7 @@
 from chaosreliably import __version__, discover
 
 
-def test_that_discover_returns_correct_discovery():
+def test_that_discover_returns_correct_discovery() -> None:
     discovery = discover()
     assert discovery["extension"]["name"] == "chaostoolkit-reliably"
     assert discovery["extension"]["version"] == __version__

--- a/tests/tolerances/test_all_objective_results_ok.py
+++ b/tests/tolerances/test_all_objective_results_ok.py
@@ -2,18 +2,18 @@ from typing import List
 from unittest.mock import MagicMock, patch
 
 from chaosreliably.slo.tolerances import all_objective_results_ok
-from chaosreliably.types import ApiObjectiveResult
+from chaosreliably.types import ObjectiveResult
 
 
 def test_all_objective_results_ok_when_results_all_ok(
-    objective_results_all_ok: List[ApiObjectiveResult],
+    objective_results_all_ok: List[ObjectiveResult],
 ) -> None:
     all_ok = all_objective_results_ok(objective_results_all_ok)
     assert all_ok
 
 
 def test_all_objective_results_ok_when_results_not_all_ok(
-    objective_results_not_all_ok: List[ApiObjectiveResult],
+    objective_results_not_all_ok: List[ObjectiveResult],
 ) -> None:
     all_ok = all_objective_results_ok(objective_results_not_all_ok)
     assert not all_ok
@@ -21,7 +21,7 @@ def test_all_objective_results_ok_when_results_not_all_ok(
 
 @patch("chaosreliably.slo.tolerances.logger")
 def test_all_objective_results_ok_doesnt_log_table_when_results_all_ok(
-    mocked_logger: MagicMock, objective_results_all_ok: List[ApiObjectiveResult]
+    mocked_logger: MagicMock, objective_results_all_ok: List[ObjectiveResult]
 ) -> None:
     _ = all_objective_results_ok(objective_results_all_ok)
     mocked_logger.info.assert_called_once_with("All Objective Results were OK.")
@@ -30,7 +30,7 @@ def test_all_objective_results_ok_doesnt_log_table_when_results_all_ok(
 @patch("chaosreliably.slo.tolerances.logger")
 def test_all_objective_results_ok_logs_table_when_all_results_not_ok(
     mocked_logger: MagicMock,
-    objective_results_not_all_ok: List[ApiObjectiveResult],
+    objective_results_not_all_ok: List[ObjectiveResult],
     not_ok_table: str,
 ) -> None:
     _ = all_objective_results_ok(objective_results_not_all_ok)

--- a/tests/tolerances/test_all_objective_results_ok.py
+++ b/tests/tolerances/test_all_objective_results_ok.py
@@ -1,31 +1,39 @@
-from unittest.mock import patch
+from typing import List
+from unittest.mock import MagicMock, patch
 
 from chaosreliably.slo.tolerances import all_objective_results_ok
+from chaosreliably.types import ApiObjectiveResult
 
 
-def test_all_objective_results_ok_when_results_all_ok(objective_results_all_ok):
+def test_all_objective_results_ok_when_results_all_ok(
+    objective_results_all_ok: List[ApiObjectiveResult],
+) -> None:
     all_ok = all_objective_results_ok(objective_results_all_ok)
     assert all_ok
 
 
-def test_all_objective_results_ok_when_results_not_all_ok(objective_results):
-    all_ok = all_objective_results_ok(objective_results)
+def test_all_objective_results_ok_when_results_not_all_ok(
+    objective_results_not_all_ok: List[ApiObjectiveResult],
+) -> None:
+    all_ok = all_objective_results_ok(objective_results_not_all_ok)
     assert not all_ok
 
 
 @patch("chaosreliably.slo.tolerances.logger")
 def test_all_objective_results_ok_doesnt_log_table_when_results_all_ok(
-    mocked_logger, objective_results_all_ok
-):
+    mocked_logger: MagicMock, objective_results_all_ok: List[ApiObjectiveResult]
+) -> None:
     _ = all_objective_results_ok(objective_results_all_ok)
     mocked_logger.info.assert_called_once_with("All Objective Results were OK.")
 
 
 @patch("chaosreliably.slo.tolerances.logger")
 def test_all_objective_results_ok_logs_table_when_all_results_not_ok(
-    mocked_logger, objective_results, not_ok_table
-):
-    _ = all_objective_results_ok(objective_results)
+    mocked_logger: MagicMock,
+    objective_results_not_all_ok: List[ApiObjectiveResult],
+    not_ok_table: str,
+) -> None:
+    _ = all_objective_results_ok(objective_results_not_all_ok)
     mocked_logger.critical.assert_called_once_with(
         "The following Objective Results were not OK:\n\n"
         "Objective Results are sorted by latest at the top:\n"


### PR DESCRIPTION
This PR adds `mypy` to the project, which itself introduces the need to:

* Fix general typing errors
* Introduce new types in `chaosreliably.types` which represent the Reliably ObjectiveResults
* Marks the project as typed for use in other projects if needed
* Updates README & Makefile to cover off addition of `mypy`

