### PR TITLE
Add `before_experiment_control` and Entity Context types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Added `chaosreliably.controls`:
   - Added `before_experiment_control` to create an Experiment, Experiment Version,
-    Experiment Run, and an Experiment Event (Start) within Reliably Entity Server.
+    Experiment Run, and an Experiment Event (Start) within Reliably services.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.2...HEAD
 
+### Added
+
+- Added `chaosreliably.controls`:
+  - Added `before_experiment_control` to create an Experiment, Experiment Version,
+    Experiment Run, and an Experiment Event (Start) within Reliably Entity Server.
+
 ### Changed
 
 - Updated `.github/workflows/build.yaml` to be in line with `chaostoolkit`

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -1,0 +1,301 @@
+from typing import Any, cast
+
+from chaoslib.types import Configuration, Experiment, Secrets
+from logzero import logger
+
+from chaosreliably import get_session
+from chaosreliably.types import (
+    EntityContext,
+    EntityContextExperimentEventLabels,
+    EntityContextExperimentLabels,
+    EntityContextExperimentRunLabels,
+    EntityContextExperimentVersionLabels,
+    EntityContextMetadata,
+    EventType,
+)
+
+__all__ = ["before_experiment_control"]
+
+
+def before_experiment_control(
+    context: Experiment,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Control run *before* the execution of an Experiment.
+
+    For a given Experiment, the control creates (if not already created) an Experiment
+    Entity Context and an Experiment Version Entity Context in the Reliably Entity
+    Server.
+
+    A unique Experiment Run Entity Context is also created, with an Experiment Event
+    Entity Context of type `EXPERIMENT_START` created, relating to the run.
+
+    The control requires the `arguments` of `commit_hash`, `source`, and `user` to be
+    provided to the control definition. If not provided, the control will simply not
+    create any Entity Contexts.
+
+    Once the Entity Contexts have been created, an entry into the configuration is made
+    under configuration["chaosreliably"]["experiment_run_labels"] to allow for
+    other controls to create events relating to the Experiment Run.
+
+    :param context: Experiment object representing the Experiment that will be executed
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :param **kwargs: Expected `kwargs` are 'commit_hash' (str), `source` (str), and
+        `user` (str)
+
+    Examples
+    --------
+
+    "controls": [
+        {
+            "name": "chaosreliably",
+            "provider": {
+                "type": "python",
+                "module": "chaosreliably.controls"
+                "arguments": {
+                    "commit_hash": "59f9f577e2d90719098f4d23d26329ce41f2d0bd",
+                    "source": "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json",  # Noqa
+                    "user": "A users name"
+                }
+            }
+        }
+    ]
+    """
+    commit_hash = kwargs.get("commit_hash")
+    source = kwargs.get("source")
+    user = kwargs.get("user")
+    if not commit_hash or not source or not user:
+        logger.warn(
+            "The parameters: `commit_hash`, `source`, and `user` are required for the"
+            "chaosreliably controls, please provide them. This Experiment Run will not"
+            "be tracked with Reliably."
+        )
+        return
+
+    experiment_run_labels = _create_experiment_entities_for_before_experiment_control(
+        experiment_title=context["title"],
+        commit_hash=commit_hash,
+        source=source,
+        user=user,
+        configuration=configuration,
+        secrets=secrets,
+    )
+
+    configuration.update(
+        {"chaosreliably": {"experiment_run_labels": experiment_run_labels.dict()}}
+    )
+
+
+def _create_entity_context_on_reliably(
+    entity_context: EntityContext, configuration: Configuration, secrets: Secrets
+) -> EntityContext:
+    """
+    For a given EntityContext, create it on the Reliably Entity Server.
+
+    :param entity_context: EntityContext which will be created on the Reliably Entity
+        Server
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContext representing the EntityContext that was just created
+    """
+    with get_session(configuration, secrets) as session:
+        url = "/entitycontext"
+        resp = session.post(url, content=entity_context.json(by_alias=True))
+        resp.raise_for_status()
+        return entity_context
+
+
+def _create_experiment(
+    experiment_title: str, configuration: Configuration, secrets: Secrets
+) -> EntityContextExperimentLabels:
+    """
+    For a given Experiment title, create a Experiment Entity Context
+    on the Reliably Entity Server.
+
+    :param experiment_title: str representing the name of the Experiment
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContextExperimentLabels representing the metadata labels of the
+        created entity - used for `relatedTo` properties in Reliably
+    """
+    experiment_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title=experiment_title)
+        )
+    )
+
+    created_entity = _create_entity_context_on_reliably(
+        entity_context=experiment_entity, configuration=configuration, secrets=secrets
+    )
+    return cast(EntityContextExperimentLabels, created_entity.metadata.labels)
+
+
+def _create_experiment_version(
+    commit_hash: str,
+    source: str,
+    experiment_labels: EntityContextExperimentLabels,
+    configuration: Configuration,
+    secrets: Secrets,
+) -> EntityContextExperimentVersionLabels:
+    """
+    For a given commit hash, source link, and Experiment labels, create a
+    ExperimentVersion Entity Context on the Reliably Entity Server.
+
+    :param commit_hash: str representing the SHA1 Hash of the current commit of the
+        Experiments repo at the time of running it
+    :param source: str representing the URL to the source control location
+        of the Experiment being run
+    :param experiment_labels: EntityContextExperimentLabels object representing the
+        labels of the Experiment this version is related to
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContextExperimentVersionLabels representing the metadata labels
+        of the created entity - used for `relatedTo` properties in Reliably
+    """
+    experiment_version_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentVersionLabels(
+                commit_hash=commit_hash,
+                source=source,
+            ),
+            related_to=[experiment_labels],
+        )
+    )
+
+    created_entity = _create_entity_context_on_reliably(
+        entity_context=experiment_version_entity,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    return cast(EntityContextExperimentVersionLabels, created_entity.metadata.labels)
+
+
+def _create_experiment_run(
+    user: str,
+    experiment_version_labels: EntityContextExperimentVersionLabels,
+    configuration: Configuration,
+    secrets: Secrets,
+) -> EntityContextExperimentRunLabels:
+    """
+    For a given user and Experiment Version labels, create a ExperimentRun Entity
+    Context on the Reliably Entity Server.
+
+    :param user: str representing the name of the user that is running the Experiment
+    :param experiment_version_labels: EntityContextExperimentVersionLabels object
+        representing the labels of the Experiment Version this run is related to
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContextExperimentRunLabels representing the metadata labels of
+        the created entity - used for `relatedTo` properties in Reliably
+    """
+    experiment_run_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentRunLabels(user=user),
+            related_to=[experiment_version_labels],
+        )
+    )
+
+    created_entity = _create_entity_context_on_reliably(
+        entity_context=experiment_run_entity,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    return cast(EntityContextExperimentRunLabels, created_entity.metadata.labels)
+
+
+def _create_experiment_event(
+    event_type: EventType,
+    name: str,
+    output: Any,
+    experiment_run_labels: EntityContextExperimentRunLabels,
+    configuration: Configuration,
+    secrets: Secrets,
+) -> EntityContextExperimentEventLabels:
+    """
+    For a given event type, name, output, and Experiment Run labels, create a
+    ExperimentEvent Entity Context on the Reliably Entity Server.
+
+    :param event_type: EventType representing the type of the Event that has happened
+    :param name: str representing the name of the Event in the Experiment
+    :param output: Any object representing the output of the event in the Experiment
+    :param experiment_run_labels: EntityContextExperimentRunLabels object
+        representing the labels of the Experiment Run this Event is related to
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContextExperimentEventLabels representing the metadata labels of
+        the created entity - used for `relatedTo` properties in Reliably
+    """
+    experiment_event_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentEventLabels(
+                event_type=event_type.value, name=name, output=output
+            ),
+            related_to=[experiment_run_labels],
+        )
+    )
+
+    created_entity = _create_entity_context_on_reliably(
+        entity_context=experiment_event_entity,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    return cast(EntityContextExperimentEventLabels, created_entity.metadata.labels)
+
+
+def _create_experiment_entities_for_before_experiment_control(
+    experiment_title: str,
+    commit_hash: str,
+    source: str,
+    user: str,
+    configuration: Configuration,
+    secrets: Secrets,
+) -> EntityContextExperimentRunLabels:
+    """
+    For a given Experiment title, commit hash, source link and user, create
+    an Experiment, Experiment Version, Experiment Run, and Experiment start Entity
+    Context on the Reliably Entity Server.
+
+    If the Experiment and version already exist, new ones will not be created, however
+    a new run is *always* created.
+
+    :param experiment_title: str representing the name of the Experiment
+    :param commit_hash: str representing the SHA1 Hash of the current commit of the
+        Experiments repo at the time of running it
+    :param source: str representing the URL to the source control location
+        of the Experiment being run
+    :param user: str representing the name of the user that is running the Experiment
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :returns: EntityContextExperimentRunLabels representing the metadata labels of
+        the Experiment Run entity - used for updating the configuration of the
+        Experiment so that Events may relate to it
+    """
+    experiment_labels = _create_experiment(
+        experiment_title=experiment_title, configuration=configuration, secrets=secrets
+    )
+    experiment_version_labels = _create_experiment_version(
+        commit_hash=commit_hash,
+        source=source,
+        experiment_labels=experiment_labels,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    experiment_run_labels = _create_experiment_run(
+        user=user,
+        experiment_version_labels=experiment_version_labels,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    _ = _create_experiment_event(
+        event_type=EventType.EXPERIMENT_START,
+        name=f"Experiment: {experiment_title} - Started",
+        output=None,
+        experiment_run_labels=experiment_run_labels,
+        configuration=configuration,
+        secrets=secrets,
+    )
+    return experiment_run_labels

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -92,7 +92,7 @@ def before_experiment_control(
         source = kwargs.get("source")
         user = kwargs.get("user")
         if not commit_hash or not source or not user:
-            logger.warn(
+            logger.debug(
                 "The parameters: `commit_hash`, `source`, and `user` are required for "
                 "the chaosreliably controls, please provide them. This Experiment Run"
                 " will not be tracked with Reliably."
@@ -117,7 +117,7 @@ def before_experiment_control(
             {"chaosreliably": {"experiment_run_labels": experiment_run_labels.dict()}}
         )
     except Exception as ex:
-        logger.warn(
+        logger.debug(
             f"An error occurred: {ex}, whilst running the Before Experiment control, "
             "no further entities will be created, the Experiment execution won't be "
             "affected"

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -65,29 +65,38 @@ def before_experiment_control(
         }
     ]
     """
-    commit_hash = kwargs.get("commit_hash")
-    source = kwargs.get("source")
-    user = kwargs.get("user")
-    if not commit_hash or not source or not user:
-        logger.warn(
-            "The parameters: `commit_hash`, `source`, and `user` are required for the"
-            "chaosreliably controls, please provide them. This Experiment Run will not"
-            "be tracked with Reliably."
+    try:
+        commit_hash = kwargs.get("commit_hash")
+        source = kwargs.get("source")
+        user = kwargs.get("user")
+        if not commit_hash or not source or not user:
+            logger.warn(
+                "The parameters: `commit_hash`, `source`, and `user` are required for "
+                "the chaosreliably controls, please provide them. This Experiment Run"
+                " will not be tracked with Reliably."
+            )
+            return
+
+        experiment_run_labels = (
+            _create_experiment_entities_for_before_experiment_control(
+                experiment_title=context["title"],
+                commit_hash=commit_hash,
+                source=source,
+                user=user,
+                configuration=configuration,
+                secrets=secrets,
+            )
         )
-        return
 
-    experiment_run_labels = _create_experiment_entities_for_before_experiment_control(
-        experiment_title=context["title"],
-        commit_hash=commit_hash,
-        source=source,
-        user=user,
-        configuration=configuration,
-        secrets=secrets,
-    )
-
-    configuration.update(
-        {"chaosreliably": {"experiment_run_labels": experiment_run_labels.dict()}}
-    )
+        configuration.update(
+            {"chaosreliably": {"experiment_run_labels": experiment_run_labels.dict()}}
+        )
+    except Exception as ex:
+        logger.warn(
+            f"An error occurred: {ex}, whilst running the Before Experiment control, "
+            "no further entities will be created, the Experiment execution won't be "
+            "affected"
+        )
 
 
 def _create_entity_context_on_reliably(

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -46,30 +46,30 @@ class ChaosToolkitType(Enum):
 
 class EntityContextExperimentLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT.value, alias="_type", const=True
+        default=ChaosToolkitType.EXPERIMENT.value, alias="ctk_type", const=True
     )
-    title: str = Field(alias="_experiment_title")
+    title: str = Field(alias="ctk_experiment_title")
 
 
 class EntityContextExperimentVersionLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_VERSION.value, alias="_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_VERSION.value, alias="ctk_type", const=True
     )
-    commit_hash: str = Field(alias="_commit_hash")
-    source: HttpUrl = Field(alias="_source")
+    commit_hash: str = Field(alias="ctk_commit_hash")
+    source: HttpUrl = Field(alias="ctk_source")
 
 
 class EntityContextExperimentRunLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="ctk_type", const=True
     )
-    id: UUID4 = Field(default=uuid4(), alias="_run_id", const=True)
+    id: UUID4 = Field(default=uuid4(), alias="ctk_run_id", const=True)
     timestamp: datetime = Field(
-        alias="_run_timestamp",
+        alias="ctk_run_timestamp",
         default=datetime.now(timezone.utc).isoformat(),
         const=True,
     )
-    user: str = Field(alias="_run_user")
+    user: str = Field(alias="ctk_run_user")
 
 
 class EventType(Enum):
@@ -78,16 +78,16 @@ class EventType(Enum):
 
 class EntityContextExperimentEventLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_EVENT.value, alias="_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_EVENT.value, alias="ctk_type", const=True
     )
-    event_type: str = Field(alias="_event_type")
+    event_type: str = Field(alias="ctk_event_type")
     timestamp: datetime = Field(
-        alias="_event_timestamp",
+        alias="ctk_event_timestamp",
         default=datetime.now(timezone.utc).isoformat(),
         const=True,
     )
-    name: str = Field(alias="_event_name")
-    output: Any = Field(alias="_event_output")
+    name: str = Field(alias="ctk_event_name")
+    output: Any = Field(alias="ctk_event_output")
 
 
 class EntityContextMetadata(BaseModel):

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -63,10 +63,10 @@ class EntityContextExperimentRunLabels(BaseModel):
     type: str = Field(
         default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="ctk_type", const=True
     )
-    id: UUID4 = Field(default=uuid4(), alias="ctk_run_id", const=True)
+    id: UUID4 = Field(default_factory=lambda: uuid4(), alias="ctk_run_id", const=True)
     timestamp: datetime = Field(
         alias="ctk_run_timestamp",
-        default=datetime.now(timezone.utc).isoformat(),
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(),
         const=True,
     )
     user: str = Field(alias="ctk_run_user")
@@ -83,7 +83,7 @@ class EntityContextExperimentEventLabels(BaseModel):
     event_type: str = Field(alias="ctk_event_type")
     timestamp: datetime = Field(
         alias="ctk_event_timestamp",
-        default=datetime.now(timezone.utc).isoformat(),
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(),
         const=True,
     )
     name: str = Field(alias="ctk_event_name")

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -1,11 +1,25 @@
-from typing import Any, Dict, List
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
 
-from pydantic import BaseModel, Field, parse_obj_as
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Field, parse_obj_as
+from pydantic.networks import HttpUrl
+from pydantic.types import UUID4
+
+OPTIONAL_DICT_LIST = Optional[List[Dict[str, Any]]]
+RELATED_TO = Field(alias="relatedTo", default=[])
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        allow_population_by_field_name = True
 
 
 class ObjectiveResultMetadata(BaseModel):
     labels: Dict[str, str]
-    related_to: List[Dict[str, str]] = Field(alias="relatedTo", default=None)
+    related_to: OPTIONAL_DICT_LIST = RELATED_TO
 
 
 class ObjectiveResultSpec(BaseModel):
@@ -21,3 +35,70 @@ class ObjectiveResult(BaseModel):
 
     def parse_list(obj: Any) -> "List[ObjectiveResult]":
         return parse_obj_as(List[ObjectiveResult], obj)
+
+
+class ChaosToolkitType(Enum):
+    EXPERIMENT: str = "Chaos Toolkit Experiment"
+    EXPERIMENT_EVENT: str = "Chaos Toolkit Experiment Event"
+    EXPERIMENT_RUN: str = "Chaos Toolkit Experiment Run"
+    EXPERIMENT_VERSION: str = "Chaos Toolkit Experiment Version"
+
+
+class EntityContextExperimentLabels(BaseModel):
+    type: str = Field(
+        default=ChaosToolkitType.EXPERIMENT.value, alias="_type", const=True
+    )
+    title: str = Field(alias="_experiment_title")
+
+
+class EntityContextExperimentVersionLabels(BaseModel):
+    type: str = Field(
+        default=ChaosToolkitType.EXPERIMENT_VERSION.value, alias="_type", const=True
+    )
+    commit_hash: str = Field(alias="_commit_hash")
+    source: HttpUrl = Field(alias="_source")
+
+
+class EntityContextExperimentRunLabels(BaseModel):
+    type: str = Field(
+        default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="_type", const=True
+    )
+    id: UUID4 = Field(default=uuid4(), alias="_run_id", const=True)
+    timestamp: datetime = Field(
+        alias="_run_timestamp",
+        default=datetime.now(timezone.utc).isoformat(),
+        const=True,
+    )
+    user: str = Field(alias="_run_user")
+
+
+class EventType(Enum):
+    EXPERIMENT_START = "EXPERIMENT_START"
+
+
+class EntityContextExperimentEventLabels(BaseModel):
+    type: str = Field(
+        default=ChaosToolkitType.EXPERIMENT_EVENT.value, alias="_type", const=True
+    )
+    event_type: str = Field(alias="_event_type")
+    timestamp: datetime = Field(
+        alias="_event_timestamp",
+        default=datetime.now(timezone.utc).isoformat(),
+        const=True,
+    )
+    name: str = Field(alias="_event_name")
+    output: Any = Field(alias="_event_output")
+
+
+class EntityContextMetadata(BaseModel):
+    labels: Union[
+        EntityContextExperimentLabels,
+        EntityContextExperimentVersionLabels,
+        EntityContextExperimentRunLabels,
+        EntityContextExperimentEventLabels,
+    ]
+    related_to: OPTIONAL_DICT_LIST = RELATED_TO
+
+
+class EntityContext(BaseModel):
+    metadata: EntityContextMetadata

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,13 @@
 coverage
 black
 flake8
+freezegun
 isort
 mypy
 pytest>=6.0
 pytest-cov
 pytest-sugar
 pytest-httpx
+types-freezegun
 types-PyYAML
 types-tabulate

--- a/tests/controls/test_before_experiment_control.py
+++ b/tests/controls/test_before_experiment_control.py
@@ -1,0 +1,386 @@
+from tempfile import NamedTemporaryFile
+from typing import Any, Dict, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_httpx
+import yaml
+from httpx._exceptions import HTTPStatusError
+
+from chaosreliably.controls import experiment
+from chaosreliably.types import (
+    EntityContext,
+    EntityContextExperimentEventLabels,
+    EntityContextExperimentLabels,
+    EntityContextExperimentRunLabels,
+    EntityContextExperimentVersionLabels,
+    EntityContextMetadata,
+    EventType,
+)
+
+
+def test_experiment_controls_exposes_correct___all___values() -> None:
+    assert "before_experiment_control" in experiment.__all__
+
+
+def test_create_entity_context_on_reliably_correctly_calls_reliably_api(
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock,
+) -> None:
+    title = "A Test Experiment Title"
+    request_url = "https://reliably.com/entities/test-org/reliably.com/v1/entitycontext"
+    expected_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title=title),
+        )
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=request_url,
+        match_content=expected_entity.json(by_alias=True).encode("utf-8"),
+    )
+    with NamedTemporaryFile(mode="w") as f:
+        yaml.safe_dump(
+            {
+                "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
+                "currentOrg": {"name": "test-org"},
+            },
+            f,
+            indent=2,
+            default_flow_style=False,
+        )
+        f.seek(0)
+
+        entity_context = experiment._create_entity_context_on_reliably(
+            entity_context=expected_entity,
+            configuration={"reliably_config_path": f.name},
+            secrets=None,
+        )
+        assert entity_context == expected_entity
+
+
+def test_create_entity_context_on_reliably_raises_exception_if_response_not_ok(
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock,
+) -> None:
+    title = "A Test Experiment Title"
+    request_url = "https://reliably.com/entities/test-org/reliably.com/v1/entitycontext"
+    expected_entity = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title=title),
+        )
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=request_url,
+        match_content=expected_entity.json(by_alias=True).encode("utf-8"),
+        status_code=500,
+    )
+    with NamedTemporaryFile(mode="w") as f:
+        yaml.safe_dump(
+            {
+                "auths": {"reliably.com": {"token": "12345", "username": "jane"}},
+                "currentOrg": {"name": "test-org"},
+            },
+            f,
+            indent=2,
+            default_flow_style=False,
+        )
+        f.seek(0)
+
+        with pytest.raises(HTTPStatusError):
+            _ = experiment._create_entity_context_on_reliably(
+                entity_context=expected_entity,
+                configuration={"reliably_config_path": f.name},
+                secrets=None,
+            )
+
+
+@patch("chaosreliably.controls.experiment._create_entity_context_on_reliably")
+def test_create_experiment_correct_calls_create_entity_context_and_returns_labels(
+    mock_create_entity_context: MagicMock,
+) -> None:
+    title = "A Test Experiment Title"
+    experiment_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title=title),
+        )
+    )
+    mock_create_entity_context.return_value = experiment_context
+
+    labels = experiment._create_experiment(
+        experiment_title=title, configuration=None, secrets=None
+    )
+
+    assert labels == experiment_context.metadata.labels
+    mock_create_entity_context.assert_called_once_with(
+        entity_context=experiment_context, configuration=None, secrets=None
+    )
+
+
+@patch("chaosreliably.controls.experiment._create_entity_context_on_reliably")
+def test_create_experiment_version_calls_create_entity_context_and_returns_labels(
+    mock_create_entity_context: MagicMock,
+) -> None:
+    commit_hash = "59f9f577e2d90719098f4d23d26329ce41f2d0bd"
+    source = "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json"
+    experiment_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title="A Test Experiment Title"),
+        )
+    )
+    experiment_version_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentVersionLabels(
+                commit_hash=commit_hash, source=source
+            ),
+            related_to=[experiment_context.metadata.labels],
+        )
+    )
+    mock_create_entity_context.return_value = experiment_version_context
+
+    labels = experiment._create_experiment_version(
+        commit_hash=commit_hash,
+        source=source,
+        experiment_labels=cast(
+            EntityContextExperimentLabels, experiment_context.metadata.labels
+        ),
+        configuration=None,
+        secrets=None,
+    )
+
+    assert labels == experiment_version_context.metadata.labels
+    mock_create_entity_context.assert_called_once_with(
+        entity_context=experiment_version_context, configuration=None, secrets=None
+    )
+
+
+@patch("chaosreliably.controls.experiment._create_entity_context_on_reliably")
+def test_create_experiment_run_calls_create_entity_context_and_returns_labels(
+    mock_create_entity_context: MagicMock,
+) -> None:
+    user = "TestUser"
+    experiment_version_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentVersionLabels(
+                commit_hash="59f9f577e2d90719098f4d23d26329ce41f2d0bd",
+                source="https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json",  # noqa
+            )
+        )
+    )
+    experiment_run_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentRunLabels(user=user),
+            related_to=[experiment_version_context.metadata.labels],
+        )
+    )
+    mock_create_entity_context.return_value = experiment_run_context
+
+    labels = experiment._create_experiment_run(
+        user=user,
+        experiment_version_labels=cast(
+            EntityContextExperimentVersionLabels,
+            experiment_version_context.metadata.labels,
+        ),
+        configuration=None,
+        secrets=None,
+    )
+
+    assert labels == experiment_run_context.metadata.labels
+    mock_create_entity_context.assert_called_once_with(
+        entity_context=experiment_run_context, configuration=None, secrets=None
+    )
+
+
+@patch("chaosreliably.controls.experiment._create_entity_context_on_reliably")
+def test_create_experiment_event_calls_create_entity_context_and_returns_labels(
+    mock_create_entity_context: MagicMock,
+) -> None:
+    event_type = EventType.EXPERIMENT_START
+    event_name = "A Start Event"
+    event_output = [1, 2, 3]
+    experiment_run_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentRunLabels(user="TestUser"),
+        )
+    )
+    experiment_event_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentEventLabels(
+                event_type=event_type.value, name=event_name, output=event_output
+            ),
+            related_to=[experiment_run_context.metadata.labels],
+        )
+    )
+    mock_create_entity_context.return_value = experiment_event_context
+
+    labels = experiment._create_experiment_event(
+        event_type=event_type,
+        name=event_name,
+        output=event_output,
+        experiment_run_labels=cast(
+            EntityContextExperimentRunLabels, experiment_run_context.metadata.labels
+        ),
+        configuration=None,
+        secrets=None,
+    )
+
+    assert labels == experiment_event_context.metadata.labels
+    mock_create_entity_context.assert_called_once_with(
+        entity_context=experiment_event_context, configuration=None, secrets=None
+    )
+
+
+@patch("chaosreliably.controls.experiment._create_experiment_event")
+@patch("chaosreliably.controls.experiment._create_experiment_run")
+@patch("chaosreliably.controls.experiment._create_experiment_version")
+@patch("chaosreliably.controls.experiment._create_experiment")
+def test_that_create_experiment_entities_for_before_experiment_control_creates_entities(
+    mock_create_experiment: MagicMock,
+    mock_create_experiment_version: MagicMock,
+    mock_create_experiment_run: MagicMock,
+    mock_create_experiment_event: MagicMock,
+) -> None:
+    title = "A title"
+    commit_hash = "59f9f577e2d90719098f4d23d26329ce41f2d0bd"
+    source = "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json"
+    user = "TestUser"
+    name = f"Experiment: {title} - Started"
+    experiment_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentLabels(title=title),
+        )
+    )
+    experiment_version_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentVersionLabels(
+                commit_hash=commit_hash,
+                source=source,
+            ),
+            related_to=[experiment_context.metadata.labels],
+        )
+    )
+    experiment_run_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentRunLabels(user=user),
+            related_to=[experiment_version_context.metadata.labels],
+        )
+    )
+    experiment_event_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentEventLabels(
+                event_type=EventType.EXPERIMENT_START.value,
+                name=name,
+                output=None,
+            ),
+            related_to=[experiment_run_context.metadata.labels],
+        )
+    )
+    mock_create_experiment.return_value = experiment_context.metadata.labels
+    mock_create_experiment_version.return_value = (
+        experiment_version_context.metadata.labels
+    )
+    mock_create_experiment_run.return_value = experiment_run_context.metadata.labels
+    mock_create_experiment_event.return_value = experiment_event_context.metadata.labels
+
+    experiment_run_labels = (
+        experiment._create_experiment_entities_for_before_experiment_control(
+            experiment_title=title,
+            commit_hash=commit_hash,
+            source=source,
+            user=user,
+            configuration=None,
+            secrets=None,
+        )
+    )
+
+    assert experiment_run_labels == experiment_run_context.metadata.labels
+
+    mock_create_experiment.assert_called_once_with(
+        experiment_title=title, configuration=None, secrets=None
+    )
+    mock_create_experiment_version.assert_called_once_with(
+        commit_hash=commit_hash,
+        source=source,
+        experiment_labels=experiment_context.metadata.labels,
+        configuration=None,
+        secrets=None,
+    )
+    mock_create_experiment_run.assert_called_once_with(
+        user=user,
+        experiment_version_labels=experiment_version_context.metadata.labels,
+        configuration=None,
+        secrets=None,
+    )
+    mock_create_experiment_event.assert_called_once_with(
+        event_type=EventType.EXPERIMENT_START,
+        name=name,
+        output=None,
+        experiment_run_labels=experiment_run_context.metadata.labels,
+        configuration=None,
+        secrets=None,
+    )
+
+
+@patch(
+    "chaosreliably.controls.experiment._create_experiment_entities_for_before_experiment_control"  # Noqa
+)
+def test_before_experiment_control_calls_create_experiment_entities(
+    mock_create_experiment_entities: MagicMock,
+) -> None:
+    configuration = {"random_config": {"hi": "hello"}, "thing": 123}
+    title = "A title"
+    commit_hash = "59f9f577e2d90719098f4d23d26329ce41f2d0bd"
+    source = "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json"
+    user = "TestUser"
+    experiment_run_context = EntityContext(
+        metadata=EntityContextMetadata(
+            labels=EntityContextExperimentRunLabels(user="a-user")
+        )
+    )
+    mock_create_experiment_entities.return_value = (
+        experiment_run_context.metadata.labels
+    )
+
+    experiment.before_experiment_control(
+        context={"title": title},
+        configuration=configuration,
+        secrets=None,
+        commit_hash=commit_hash,
+        source=source,
+        user=user,
+    )
+
+    mock_create_experiment_entities.assert_called_once_with(
+        experiment_title=title,
+        commit_hash=commit_hash,
+        source=source,
+        user=user,
+        configuration=configuration,
+        secrets=None,
+    )
+
+    assert "chaosreliably" in configuration
+    chaosreliably = cast(Dict[str, Any], configuration["chaosreliably"])
+    assert (
+        chaosreliably["experiment_run_labels"] == experiment_run_context.metadata.labels
+    )
+
+
+@patch("chaosreliably.controls.experiment.logger")
+@patch(
+    "chaosreliably.controls.experiment._create_experiment_entities_for_before_experiment_control"  # Noqa
+)
+def test_that_before_experiment_control_does_nothing_if_kwargs_not_present(
+    mock_create_experiment_entities: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    experiment.before_experiment_control(
+        context={"title": "a-title"},
+        configuration=None,
+        secrets=None,
+    )
+    mock_logger.warn.assert_called_once_with(
+        "The parameters: `commit_hash`, `source`, and `user` are required for the"
+        "chaosreliably controls, please provide them. This Experiment Run will not"
+        "be tracked with Reliably."
+    )
+    mock_create_experiment_entities.assert_not_called()

--- a/tests/controls/test_before_experiment_control.py
+++ b/tests/controls/test_before_experiment_control.py
@@ -379,8 +379,31 @@ def test_that_before_experiment_control_does_nothing_if_kwargs_not_present(
         secrets=None,
     )
     mock_logger.warn.assert_called_once_with(
-        "The parameters: `commit_hash`, `source`, and `user` are required for the"
-        "chaosreliably controls, please provide them. This Experiment Run will not"
+        "The parameters: `commit_hash`, `source`, and `user` are required for the "
+        "chaosreliably controls, please provide them. This Experiment Run will not "
         "be tracked with Reliably."
     )
     mock_create_experiment_entities.assert_not_called()
+
+
+@patch("chaosreliably.controls.experiment.logger")
+@patch(
+    "chaosreliably.controls.experiment._create_experiment_entities_for_before_experiment_control"  # Noqa
+)
+def test_that_an_exception_does_not_get_raised_and_warning_logged(
+    mock_create_experiment_entities: MagicMock, mock_logger: MagicMock
+) -> None:
+    mock_create_experiment_entities.side_effect = Exception("An exception happened")
+    experiment.before_experiment_control(
+        context={"title": "a-title"},
+        configuration=None,
+        secrets=None,
+        commit_hash="blah",
+        source="blah",
+        user="blah",
+    )
+    mock_logger.warn.assert_called_once_with(
+        "An error occurred: An exception happened, whilst running the Before Experiment"
+        " control, no further entities will be created, the Experiment execution won't"
+        " be affected"
+    )

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -1,5 +1,5 @@
 from tempfile import NamedTemporaryFile
-from typing import Any, List
+from typing import Any
 from urllib.parse import quote
 
 import pytest
@@ -8,7 +8,6 @@ import yaml
 from chaoslib.exceptions import ActivityFailed
 
 from chaosreliably.slo.probes import get_objective_results_by_labels
-from chaosreliably.types import ObjectiveResult
 
 
 def test_that_get_objective_results_by_label_returns_correct_results(
@@ -80,7 +79,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(
 
 
 def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
-    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: List[ObjectiveResult]
+    httpx_mock: pytest_httpx._httpx_mock.HTTPXMock, results: Any
 ) -> None:
     labels = {
         "name": "exploring-reliability-guide",


### PR DESCRIPTION
This PR begins to add support for Controls to `chaosreliably`.

It adds types under `chaosreliably.types` to support Reliably Entity Server EntityContexts.

It also adds the `before_experiment_control` which when invoked will:
  * Create an Experiment EntityContext on Reliably (If already present, this is fine)
  * Create an Experiment Version EntityContext on Reliably (If already present, this is fine)
  * Create an Experiment Run EntityContext which is unique to the current run on Reliably
  * Create an Experiment Event (Start) EntityContext on Reliably

Relationships go as:

Experiment Version is related to the Experiment
Experiment Run is related to the Experiment Version
Experiment Events are related to the Experiment Run
