### PR TITLE
Add before and after method controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     Experiment Run, and an Experiment Event (Start) within Reliably services.
   - Added `before_hypothesis_control` and `after_hypothesis_control` to create
     Experiment Events within Reliably services.
+  - Added `before_method_control` and `after_method_control` to create Experiment
+    Events within Reliably services.
 
 ### Changed
 

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, cast
 
-from chaoslib.types import Configuration, Experiment, Hypothesis, Secrets
+from chaoslib.types import Configuration, Experiment, Hypothesis, Run, Secrets
 from logzero import logger
 
 from chaosreliably import get_session
@@ -16,6 +16,7 @@ from chaosreliably.types import (
 
 __all__ = [
     "after_hypothesis_control",
+    "after_method_control",
     "before_experiment_control",
     "before_hypothesis_control",
     "before_method_control",
@@ -241,6 +242,31 @@ def before_method_control(
     except Exception as ex:
         logger.debug(
             f"An error occurred: {ex}, while running the Before Method control, the"
+            " Experiment execution won't be affected."
+        )
+
+
+def after_method_control(
+    context: Experiment,
+    state: List[Run],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs: Any,
+) -> None:
+    try:
+        _create_experiment_event(
+            event_type=EventType.METHOD_END,
+            name=f"{context['title']} - Method End",
+            output=state,
+            experiment_run_labels=configuration["chaosreliably"][
+                "experiment_run_labels"
+            ],
+            configuration=configuration,
+            secrets=secrets,
+        )
+    except Exception as ex:
+        logger.debug(
+            f"An error occurred: {ex}, while running the After Method control, the"
             " Experiment execution won't be affected."
         )
 

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -18,6 +18,7 @@ __all__ = [
     "after_hypothesis_control",
     "before_experiment_control",
     "before_hypothesis_control",
+    "before_method_control",
 ]
 
 
@@ -135,7 +136,7 @@ def before_hypothesis_control(
     **kwargs: Any,
 ) -> None:
     """
-    Control run *before* the execution of an Experiments Steady State Hypothesis
+    Control run *before* the execution of an Experiments Steady State Hypothesis.
 
     For a given Steady State Hypothesis, the control creates an Experiment Event Entity
     Context in the Reliably service.
@@ -174,7 +175,7 @@ def after_hypothesis_control(
     **kwargs: Any,
 ) -> None:
     """
-    Control run *after* the execution of an Experiments Steady State Hypothesis
+    Control run *after* the execution of an Experiments Steady State Hypothesis.
 
     For a given Steady State Hypothesis and its state, post execution, the control
     creates an Experiment Event Entity Context in the Reliably service.
@@ -203,6 +204,43 @@ def after_hypothesis_control(
     except Exception as ex:
         logger.debug(
             f"An error occurred: {ex}, while running the After Hypothesis control, the"
+            " Experiment execution won't be affected."
+        )
+
+
+def before_method_control(
+    context: Experiment,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Control run *before* the execution of an Experiments Method.
+
+    For a given Experiment, the control creates an Experiment Event Entity Context in
+    the Reliably service.
+
+    The Event has the `event_type` of `METHOD_START`.
+
+    :param context: Experiment object representing the Experiment that will be executed
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :param **kwargs: Any additional keyword arguments passed to the control
+    """
+    try:
+        _create_experiment_event(
+            event_type=EventType.METHOD_START,
+            name=f"{context['title']} - Method Start",
+            output=None,
+            experiment_run_labels=configuration["chaosreliably"][
+                "experiment_run_labels"
+            ],
+            configuration=configuration,
+            secrets=secrets,
+        )
+    except Exception as ex:
+        logger.debug(
+            f"An error occurred: {ex}, while running the Before Method control, the"
             " Experiment execution won't be affected."
         )
 

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -253,6 +253,21 @@ def after_method_control(
     secrets: Secrets = None,
     **kwargs: Any,
 ) -> None:
+    """
+    Control run *after* the execution of an Experiments Method.
+
+    For a given Experiment, the control creates an Experiment Event Entity Context in
+    the Reliably service.
+
+    The Event has the `event_type` of `METHOD_END`.
+
+    :param context: Experiment object representing the Experiment that will be executed
+    :param state: List[Run] object presenting the executed Activities within the
+        Experiments Method
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :param **kwargs: Any additional keyword arguments passed to the control
+    """
     try:
         _create_experiment_event(
             event_type=EventType.METHOD_END,

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -77,6 +77,7 @@ class EventType(Enum):
     HYPOTHESIS_END = "HYPOTHESIS_END"
     HYPOTHESIS_START = "HYPOTHESIS_START"
     METHOD_START = "METHOD_START"
+    METHOD_END = "METHOD_END"
 
 
 class EntityContextExperimentEventLabels(BaseModel):

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -76,6 +76,7 @@ class EventType(Enum):
     EXPERIMENT_START = "EXPERIMENT_START"
     HYPOTHESIS_END = "HYPOTHESIS_END"
     HYPOTHESIS_START = "HYPOTHESIS_START"
+    METHOD_START = "METHOD_START"
 
 
 class EntityContextExperimentEventLabels(BaseModel):

--- a/tests/controls/test_after_method_control.py
+++ b/tests/controls/test_after_method_control.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, cast
+from unittest.mock import MagicMock, patch
+
+from chaosreliably.controls import experiment
+from chaosreliably.types import EntityContextExperimentRunLabels, EventType
+
+
+@patch("chaosreliably.controls.experiment._create_experiment_event")
+def test_after_method_control_calls_create_experiment_event(
+    mock_create_experiment_event: MagicMock,
+) -> None:
+    run_labels = EntityContextExperimentRunLabels(user="TestUser")
+    title = "Test Experiment Title"
+    name = f"{title} - Method End"
+    configuration = {"chaosreliably": {"experiment_run_labels": run_labels.dict()}}
+    probe = {
+        "type": "probe",
+        "name": "test-probe",
+        "tolerance": True,
+        "provider": {
+            "type": "python",
+            "module": "test.module",
+            "func": "test_func",
+        },
+    }
+    run = {
+        "activity": probe,
+        "output": False,
+        "status": "succeeded",
+        "start": "2021-08-17T08:34:46.884325",
+        "end": "2021-08-17T08:34:46.891386",
+        "duration": 0.007061,
+        "tolerance_met": False,
+    }
+
+    experiment.after_method_control(
+        context={"title": title, "description": "A test description", "method": []},
+        **cast(
+            Dict[str, Any],
+            {"state": [run], "configuration": configuration, "secrets": None},
+        ),
+    )
+
+    mock_create_experiment_event.assert_called_once_with(
+        event_type=EventType.METHOD_END,
+        name=name,
+        output=[run],
+        experiment_run_labels=run_labels,
+        configuration=configuration,
+        secrets=None,
+    )
+
+
+@patch("chaosreliably.controls.experiment.logger")
+def test_that_an_exception_does_not_get_raised_and_warning_logged(
+    mock_logger: MagicMock,
+) -> None:
+
+    experiment.after_method_control(
+        context={
+            "title": "Test Experiment Title",
+            "description": "A test description",
+            "method": [],
+        },
+        **cast(Dict[str, Any], {"configuration": {}, "state": [], "secrets": None}),
+    )
+    mock_logger.debug.assert_called_once_with(
+        "An error occurred: 'chaosreliably', while running the After Method "
+        "control, the Experiment execution won't be affected."
+    )

--- a/tests/controls/test_before_method_control.py
+++ b/tests/controls/test_before_method_control.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+from chaosreliably.controls import experiment
+from chaosreliably.types import EntityContextExperimentRunLabels, EventType
+
+
+@patch("chaosreliably.controls.experiment._create_experiment_event")
+def test_before_method_control_calls_create_experiment_event(
+    mock_create_experiment_event: MagicMock,
+) -> None:
+    run_labels = EntityContextExperimentRunLabels(user="TestUser")
+    title = "Test Experiment Title"
+    name = f"{title} - Method Start"
+    configuration = {"chaosreliably": {"experiment_run_labels": run_labels.dict()}}
+
+    experiment.before_method_control(
+        context={"title": title, "description": "A test description", "method": []},
+        **{"configuration": configuration, "secrets": None},
+    )
+
+    mock_create_experiment_event.assert_called_once_with(
+        event_type=EventType.METHOD_START,
+        name=name,
+        output=None,
+        experiment_run_labels=run_labels,
+        configuration=configuration,
+        secrets=None,
+    )
+
+
+@patch("chaosreliably.controls.experiment.logger")
+def test_that_an_exception_does_not_get_raised_and_warning_logged(
+    mock_logger: MagicMock,
+) -> None:
+
+    experiment.before_method_control(
+        context={
+            "title": "Test Experiment Title",
+            "description": "A test description",
+            "method": [],
+        },
+        **{"configuration": {}, "secrets": None},
+    )
+    mock_logger.debug.assert_called_once_with(
+        "An error occurred: 'chaosreliably', while running the Before Method "
+        "control, the Experiment execution won't be affected."
+    )

--- a/tests/controls/test_experiment_controls.py
+++ b/tests/controls/test_experiment_controls.py
@@ -6,5 +6,6 @@ def test_experiment_controls_exposes_correct___all___values() -> None:
         "before_experiment_control",
         "before_hypothesis_control",
         "after_hypothesis_control",
+        "before_method_control",
     ]:
         assert func in experiment.__all__

--- a/tests/controls/test_experiment_controls.py
+++ b/tests/controls/test_experiment_controls.py
@@ -7,5 +7,6 @@ def test_experiment_controls_exposes_correct___all___values() -> None:
         "before_hypothesis_control",
         "after_hypothesis_control",
         "before_method_control",
+        "after_method_control",
     ]:
         assert func in experiment.__all__


### PR DESCRIPTION
This PR adds the `before_method_control` and `after_method_control` controls to `chaosreliably`
