### PR TITLE
Add before and after rollback controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
     Experiment Events within Reliably services.
   - Added `before_method_control` and `after_method_control` to create Experiment
     Events within Reliably services.
+  - Added `before_rollback_control` and `after_rollback_control` to create
+    Experiment Events within Reliably services.
 
 ### Changed
 

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -17,9 +17,11 @@ from chaosreliably.types import (
 __all__ = [
     "after_hypothesis_control",
     "after_method_control",
+    "after_rollback_control",
     "before_experiment_control",
     "before_hypothesis_control",
     "before_method_control",
+    "before_rollback_control",
 ]
 
 
@@ -256,8 +258,8 @@ def after_method_control(
     """
     Control run *after* the execution of an Experiments Method.
 
-    For a given Experiment, the control creates an Experiment Event Entity Context in
-    the Reliably service.
+    For a given Experiment Method and its state, the control creates an Experiment
+    Event Entity Context in the Reliably service.
 
     The Event has the `event_type` of `METHOD_END`.
 
@@ -282,6 +284,83 @@ def after_method_control(
     except Exception as ex:
         logger.debug(
             f"An error occurred: {ex}, while running the After Method control, the"
+            " Experiment execution won't be affected."
+        )
+
+
+def before_rollback_control(
+    context: Experiment,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Control run *before* the execution of an Experiments Rollback.
+
+    For a given Experiment, the control creates an Experiment Event Entity Context in
+    the Reliably service.
+
+    The Event has the `event_type` of `ROLLBACK_START`.
+
+    :param context: Experiment object representing the Experiment that will be executed
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :param **kwargs: Any additional keyword arguments passed to the control
+    """
+    try:
+        _create_experiment_event(
+            event_type=EventType.ROLLBACK_START,
+            name=f"{context['title']} - Rollback Start",
+            output=None,
+            experiment_run_labels=configuration["chaosreliably"][
+                "experiment_run_labels"
+            ],
+            configuration=configuration,
+            secrets=secrets,
+        )
+    except Exception as ex:
+        logger.debug(
+            f"An error occurred: {ex}, while running the Before Rollback control, the"
+            " Experiment execution won't be affected."
+        )
+
+
+def after_rollback_control(
+    context: Experiment,
+    state: List[Run],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs: Any,
+) -> None:
+    """
+    Control run *after* the execution of an Experiments Rollback.
+
+    For a given Experiment Rollback and its state, the control creates an Experiment
+    Event Entity Context in the Reliably service.
+
+    The Event has the `event_type` of `ROLLBACK_END`.
+
+    :param context: Experiment object representing the Experiment that will be executed
+    :param state: List[Run] object presenting the executed Activities within the
+        Experiments Rollback
+    :param configuration: Configuration object provided by Chaos Toolkit
+    :param secrets: Secret object provided by Chaos Toolkit
+    :param **kwargs: Any additional keyword arguments passed to the control
+    """
+    try:
+        _create_experiment_event(
+            event_type=EventType.ROLLBACK_END,
+            name=f"{context['title']} - Rollback End",
+            output=state,
+            experiment_run_labels=configuration["chaosreliably"][
+                "experiment_run_labels"
+            ],
+            configuration=configuration,
+            secrets=secrets,
+        )
+    except Exception as ex:
+        logger.debug(
+            f"An error occurred: {ex}, while running the After Rollback control, the"
             " Experiment execution won't be affected."
         )
 

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -78,6 +78,8 @@ class EventType(Enum):
     HYPOTHESIS_START = "HYPOTHESIS_START"
     METHOD_START = "METHOD_START"
     METHOD_END = "METHOD_END"
+    ROLLBACK_START = "ROLLBACK_START"
+    ROLLBACK_END = "ROLLBACK_END"
 
 
 class EntityContextExperimentEventLabels(BaseModel):

--- a/tests/controls/test_after_rollback_control.py
+++ b/tests/controls/test_after_rollback_control.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, cast
+from unittest.mock import MagicMock, patch
+
+from chaosreliably.controls import experiment
+from chaosreliably.types import EntityContextExperimentRunLabels, EventType
+
+
+@patch("chaosreliably.controls.experiment._create_experiment_event")
+def test_after_method_control_calls_create_experiment_event(
+    mock_created_experiment_event: MagicMock,
+) -> None:
+    run_labels = EntityContextExperimentRunLabels(user="TestUser")
+    title = "Test Experiment Title"
+    name = f"{title} - Rollback End"
+    configuration = {"chaosreliably": {"experiment_run_labels": run_labels.dict()}}
+    probe = {
+        "type": "probe",
+        "name": "test-probe",
+        "provider": {
+            "type": "python",
+            "module": "test.module",
+            "func": "test_func",
+        },
+    }
+    run = {
+        "activity": probe,
+        "output": None,
+        "status": "succeeded",
+        "start": "2021-08-17T08:34:46.884325",
+        "end": "2021-08-17T08:34:46.891386",
+        "duration": 0.007061,
+    }
+
+    experiment.after_rollback_control(
+        context={"title": title, "description": "A test description", "method": []},
+        **cast(
+            Dict[str, Any],
+            {"state": [run], "configuration": configuration, "secrets": None},
+        ),
+    )
+
+    mock_created_experiment_event.assert_called_once_with(
+        event_type=EventType.ROLLBACK_END,
+        name=name,
+        output=[run],
+        experiment_run_labels=run_labels,
+        configuration=configuration,
+        secrets=None,
+    )
+
+
+@patch("chaosreliably.controls.experiment.logger")
+def test_that_an_exception_does_not_get_raised_and_warning_logged(
+    mock_logger: MagicMock,
+) -> None:
+
+    experiment.after_rollback_control(
+        context={
+            "title": "Test Experiment Title",
+            "description": "A test description",
+            "method": [],
+        },
+        **cast(Dict[str, Any], {"configuration": {}, "state": [], "secrets": None}),
+    )
+
+    mock_logger.debug.assert_called_once_with(
+        "An error occurred: 'chaosreliably', while running the After Rollback control,"
+        " the Experiment execution won't be affected."
+    )

--- a/tests/controls/test_before_rollback_control.py
+++ b/tests/controls/test_before_rollback_control.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+from chaosreliably.controls import experiment
+from chaosreliably.types import EntityContextExperimentRunLabels, EventType
+
+
+@patch("chaosreliably.controls.experiment._create_experiment_event")
+def test_before_rollback_control_calls_create_experiment_event(
+    mock_create_experiment_event: MagicMock,
+) -> None:
+    run_labels = EntityContextExperimentRunLabels(user="TestUser")
+    title = "Test Experiment Title"
+    name = f"{title} - Rollback Start"
+    configuration = {"chaosreliably": {"experiment_run_labels": run_labels.dict()}}
+
+    experiment.before_rollback_control(
+        context={"title": title, "description": "A test description", "method": []},
+        **{"configuration": configuration, "secrets": None},
+    )
+
+    mock_create_experiment_event.assert_called_once_with(
+        event_type=EventType.ROLLBACK_START,
+        name=name,
+        output=None,
+        experiment_run_labels=run_labels,
+        configuration=configuration,
+        secrets=None,
+    )
+
+
+@patch("chaosreliably.controls.experiment.logger")
+def test_that_an_exception_does_not_get_raised_and_warning_logged(
+    mock_logger: MagicMock,
+) -> None:
+
+    experiment.before_rollback_control(
+        context={
+            "title": "Test Experiment Title",
+            "description": "A test description",
+            "method": [],
+        },
+        **{"configuration": {}, "secrets": None},
+    )
+
+    mock_logger.debug.assert_called_once_with(
+        "An error occurred: 'chaosreliably', while running the Before Rollback control,"
+        " the Experiment execution won't be affected."
+    )

--- a/tests/controls/test_experiment_controls.py
+++ b/tests/controls/test_experiment_controls.py
@@ -8,5 +8,7 @@ def test_experiment_controls_exposes_correct___all___values() -> None:
         "after_hypothesis_control",
         "before_method_control",
         "after_method_control",
+        "before_rollback_control",
+        "after_rollback_control",
     ]:
         assert func in experiment.__all__


### PR DESCRIPTION
This PR adds the `before_rollback_control` and `after_rollback_control` to `chaosreliably`

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
