### PR TITLE
Make modifications after testing against Reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.3.0...HEAD
 
+### Changed
+
+* Fixed labels sent to Reliably to use alias field names
+* Corrected docstring examples of control usage
+* Modified output label entry for experiment events to be strings
+* Change `ctk_type` label entry to be `entity-type`
+
 ## [0.3.0][]
 
 [0.3.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/compare/0.2.2...0.3.0

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -74,7 +74,7 @@ def before_experiment_control(
             "name": "chaosreliably",
             "provider": {
                 "type": "python",
-                "module": "chaosreliably.controls"
+                "module": "chaosreliably.controls",
                 "arguments": {
                     "commit_hash": "59f9f577e2d90719098f4d23d26329ce41f2d0bd",
                     "source": "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json",  # Noqa
@@ -90,7 +90,7 @@ def before_experiment_control(
             "name": "chaosreliably",
             "provider": {
                 "type": "python",
-                "module": "chaosreliably.controls"
+                "module": "chaosreliably.controls",
                 "arguments": {
                     "commit_hash": "59f9f577e2d90719098f4d23d26329ce41f2d0bd",
                     "source": "https://github.com/chaostoolkit-incubator/chaostoolkit-reliably/exp.json",  # Noqa

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -107,6 +107,7 @@ def before_experiment_control(
     ]
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         commit_hash = kwargs.get("commit_hash")
         source = kwargs.get("source")
         user = kwargs.get("user")
@@ -127,7 +128,7 @@ def before_experiment_control(
                 source=source,
                 user=user,
                 configuration=configuration,
-                secrets=secrets,
+                secrets=reliably_secrets,
                 experiment_related_to_labels=experiment_related_to_labels,
             )
         )
@@ -166,6 +167,7 @@ def after_experiment_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.EXPERIMENT_END,
             name=f"Experiment: {context['title']} - Ended",
@@ -174,7 +176,7 @@ def after_experiment_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -204,6 +206,7 @@ def before_hypothesis_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.HYPOTHESIS_START,
             name=context["title"],
@@ -212,7 +215,7 @@ def before_hypothesis_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -245,6 +248,7 @@ def after_hypothesis_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.HYPOTHESIS_END,
             name=context["title"],
@@ -253,7 +257,7 @@ def after_hypothesis_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -282,6 +286,7 @@ def before_method_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.METHOD_START,
             name=f"{context['title']} - Method Start",
@@ -290,7 +295,7 @@ def before_method_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -322,6 +327,7 @@ def after_method_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.METHOD_END,
             name=f"{context['title']} - Method End",
@@ -330,7 +336,7 @@ def after_method_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -359,6 +365,7 @@ def before_rollback_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.ROLLBACK_START,
             name=f"{context['title']} - Rollback Start",
@@ -367,7 +374,7 @@ def before_rollback_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -399,6 +406,7 @@ def after_rollback_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.ROLLBACK_END,
             name=f"{context['title']} - Rollback End",
@@ -407,7 +415,7 @@ def after_rollback_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -437,6 +445,7 @@ def before_activity_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.ACTIVITY_START,
             name=context["name"],
@@ -445,7 +454,7 @@ def before_activity_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(
@@ -477,6 +486,7 @@ def after_activity_control(
     :param **kwargs: Any additional keyword arguments passed to the control
     """
     try:
+        reliably_secrets = secrets.get("reliably", None) if secrets else None
         _create_experiment_event(
             event_type=EventType.ACTIVITY_END,
             name=context["name"],
@@ -485,7 +495,7 @@ def after_activity_control(
                 "experiment_run_labels"
             ],
             configuration=configuration,
-            secrets=secrets,
+            secrets=reliably_secrets,
         )
     except Exception as ex:
         logger.debug(

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -648,7 +648,7 @@ def _create_experiment_event(
     experiment_event_entity = EntityContext(
         metadata=EntityContextMetadata(
             labels=EntityContextExperimentEventLabels(
-                event_type=event_type.value, name=name, output=output
+                event_type=event_type.value, name=name, output=str(output)
             ),
             related_to=[experiment_run_labels],
         )

--- a/chaosreliably/controls/experiment.py
+++ b/chaosreliably/controls/experiment.py
@@ -133,7 +133,7 @@ def before_experiment_control(
         )
 
         configuration.update(
-            {"chaosreliably": {"experiment_run_labels": experiment_run_labels.dict()}}
+            {"chaosreliably": {"experiment_run_labels": experiment_run_labels}}
         )
     except Exception as ex:
         logger.debug(
@@ -538,7 +538,10 @@ def _create_experiment(
     created_entity = _create_entity_context_on_reliably(
         entity_context=experiment_entity, configuration=configuration, secrets=secrets
     )
-    return cast(EntityContextExperimentLabels, created_entity.metadata.labels)
+    return cast(
+        EntityContextExperimentLabels,
+        created_entity.metadata.labels.dict(by_alias=True),
+    )
 
 
 def _create_experiment_version(
@@ -578,7 +581,10 @@ def _create_experiment_version(
         configuration=configuration,
         secrets=secrets,
     )
-    return cast(EntityContextExperimentVersionLabels, created_entity.metadata.labels)
+    return cast(
+        EntityContextExperimentVersionLabels,
+        created_entity.metadata.labels.dict(by_alias=True),
+    )
 
 
 def _create_experiment_run(
@@ -611,7 +617,10 @@ def _create_experiment_run(
         configuration=configuration,
         secrets=secrets,
     )
-    return cast(EntityContextExperimentRunLabels, created_entity.metadata.labels)
+    return cast(
+        EntityContextExperimentRunLabels,
+        created_entity.metadata.labels.dict(by_alias=True),
+    )
 
 
 def _create_experiment_event(
@@ -650,7 +659,10 @@ def _create_experiment_event(
         configuration=configuration,
         secrets=secrets,
     )
-    return cast(EntityContextExperimentEventLabels, created_entity.metadata.labels)
+    return cast(
+        EntityContextExperimentEventLabels,
+        created_entity.metadata.labels.dict(by_alias=True),
+    )
 
 
 def _create_experiment_entities_for_before_experiment_control(

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -38,22 +38,24 @@ class ObjectiveResult(BaseModel):
 
 
 class ChaosToolkitType(Enum):
-    EXPERIMENT: str = "Chaos Toolkit Experiment"
-    EXPERIMENT_EVENT: str = "Chaos Toolkit Experiment Event"
-    EXPERIMENT_RUN: str = "Chaos Toolkit Experiment Run"
-    EXPERIMENT_VERSION: str = "Chaos Toolkit Experiment Version"
+    EXPERIMENT: str = "chaos-toolkit-experiment"
+    EXPERIMENT_EVENT: str = "chaos-toolkit-experiment-event"
+    EXPERIMENT_RUN: str = "chaos-toolkit-experiment-run"
+    EXPERIMENT_VERSION: str = "chaos-toolkit-experiment-version"
 
 
 class EntityContextExperimentLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT.value, alias="ctk_type", const=True
+        default=ChaosToolkitType.EXPERIMENT.value, alias="entity-type", const=True
     )
     title: str = Field(alias="ctk_experiment_title")
 
 
 class EntityContextExperimentVersionLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_VERSION.value, alias="ctk_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_VERSION.value,
+        alias="entity-type",
+        const=True,
     )
     commit_hash: str = Field(alias="ctk_commit_hash")
     source: HttpUrl = Field(alias="ctk_source")
@@ -61,7 +63,7 @@ class EntityContextExperimentVersionLabels(BaseModel):
 
 class EntityContextExperimentRunLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="ctk_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_RUN.value, alias="entity-type", const=True
     )
     id: UUID4 = Field(default_factory=lambda: uuid4(), alias="ctk_run_id", const=True)
     timestamp: datetime = Field(
@@ -87,7 +89,7 @@ class EventType(Enum):
 
 class EntityContextExperimentEventLabels(BaseModel):
     type: str = Field(
-        default=ChaosToolkitType.EXPERIMENT_EVENT.value, alias="ctk_type", const=True
+        default=ChaosToolkitType.EXPERIMENT_EVENT.value, alias="entity-type", const=True
     )
     event_type: str = Field(alias="ctk_event_type")
     timestamp: datetime = Field(

--- a/chaosreliably/types.py
+++ b/chaosreliably/types.py
@@ -96,7 +96,7 @@ class EntityContextExperimentEventLabels(BaseModel):
         const=True,
     )
     name: str = Field(alias="ctk_event_name")
-    output: Any = Field(alias="ctk_event_output")
+    output: str = Field(alias="ctk_event_output")
 
 
 class EntityContextMetadata(BaseModel):

--- a/tests/controls/test_before_experiment_control.py
+++ b/tests/controls/test_before_experiment_control.py
@@ -53,7 +53,7 @@ def test_that_create_experiment_entities_for_before_experiment_control_creates_e
             labels=EntityContextExperimentEventLabels(
                 event_type=EventType.EXPERIMENT_START.value,
                 name=name,
-                output=None,
+                output=str(None),
             ),
             related_to=[experiment_run_context.metadata.labels],
         )
@@ -149,7 +149,7 @@ def test_that_create_experiment_entities_for_before_experiment_control_creates_e
             labels=EntityContextExperimentEventLabels(
                 event_type=EventType.EXPERIMENT_START.value,
                 name=name,
-                output=None,
+                output=str(None),
             ),
             related_to=[experiment_run_context.metadata.labels],
         )

--- a/tests/controls/test_entity_creation.py
+++ b/tests/controls/test_entity_creation.py
@@ -233,7 +233,7 @@ def test_create_experiment_event_calls_create_entity_context_and_returns_labels(
 ) -> None:
     event_type = EventType.EXPERIMENT_START
     event_name = "A Start Event"
-    event_output = [1, 2, 3]
+    event_output = str([1, 2, 3])
     experiment_run_context = EntityContext(
         metadata=EntityContextMetadata(
             labels=EntityContextExperimentRunLabels(user="TestUser"),

--- a/tests/controls/test_entity_creation.py
+++ b/tests/controls/test_entity_creation.py
@@ -109,7 +109,7 @@ def test_create_experiment_correct_calls_create_entity_context_and_returns_label
         experiment_title=title, configuration=None, secrets=None
     )
 
-    assert labels == experiment_context.metadata.labels
+    assert labels == experiment_context.metadata.labels.dict(by_alias=True)
     mock_create_entity_context.assert_called_once_with(
         entity_context=experiment_context, configuration=None, secrets=None
     )
@@ -139,7 +139,7 @@ def test_create_experiment_with_related_to_labels_correct_calls_create_entity_co
         secrets=None,
     )
 
-    assert labels == experiment_context.metadata.labels
+    assert labels == experiment_context.metadata.labels.dict(by_alias=True)
     mock_create_entity_context.assert_called_once_with(
         entity_context=experiment_context, configuration=None, secrets=None
     )
@@ -176,7 +176,7 @@ def test_create_experiment_version_calls_create_entity_context_and_returns_label
         secrets=None,
     )
 
-    assert labels == experiment_version_context.metadata.labels
+    assert labels == experiment_version_context.metadata.labels.dict(by_alias=True)
     mock_create_entity_context.assert_called_once_with(
         entity_context=experiment_version_context, configuration=None, secrets=None
     )
@@ -218,7 +218,7 @@ def test_create_experiment_run_calls_create_entity_context_and_returns_labels(
         secrets=None,
     )
 
-    assert labels == experiment_run_context.metadata.labels
+    assert labels == experiment_run_context.metadata.labels.dict(by_alias=True)
     mock_create_entity_context.assert_called_once_with(
         entity_context=experiment_run_context, configuration=None, secrets=None
     )
@@ -260,7 +260,7 @@ def test_create_experiment_event_calls_create_entity_context_and_returns_labels(
         secrets=None,
     )
 
-    assert labels == experiment_event_context.metadata.labels
+    assert labels == experiment_event_context.metadata.labels.dict(by_alias=True)
     mock_create_entity_context.assert_called_once_with(
         entity_context=experiment_event_context, configuration=None, secrets=None
     )


### PR DESCRIPTION
This PR addresses issues found whilst using `chaosreliably` as a control to interact with Reliably.

The issues addressed are:
* Doc string examples were missing commas
* Labels returned by functions were returning with python field names, not their aliases which are specific
for use with Reliably
* Reliably complained rightly, that it couldn't handle nested objects as labels (specifically `output` of
experiment events) - these are now dumped as a string
* The webapp uses `entity-type` as the label key to differentiate types of entity contexts, I switched
`ctk_type` to be `entity-type` and kebab-cased the values to map the webapps expectations
* Extract the `reliably` secrets in the control block, this is because controls themselves receive *all* secrets
