### PR TITLE
Reliably now puts APIs behind `/api/*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Corrected docstring examples of control usage
 * Modified output label entry for experiment events to be strings
 * Change `ctk_type` label entry to be `entity-type`
+* Change url to reliably to now include `/api/*` as Reliably changed routes to
+services
 
 ## [0.3.0][]
 

--- a/chaosreliably/__init__.py
+++ b/chaosreliably/__init__.py
@@ -27,7 +27,8 @@ def get_session(
     with httpx.Client() as client:
         client.headers = httpx.Headers(headers)
         client.base_url = httpx.URL(
-            f"https://{auth_info['host']}/entities/{auth_info['org']}/reliably.com/v1"
+            f"https://{auth_info['host']}/api/entities/"
+            f"{auth_info['org']}/reliably.com/v1"
         )
         yield client
 

--- a/tests/controls/test_entity_creation.py
+++ b/tests/controls/test_entity_creation.py
@@ -26,7 +26,9 @@ def test_create_entity_context_on_reliably_correctly_calls_reliably_api(
     httpx_mock: pytest_httpx._httpx_mock.HTTPXMock,
 ) -> None:
     title = "A Test Experiment Title"
-    request_url = "https://reliably.com/entities/test-org/reliably.com/v1/entitycontext"
+    request_url = (
+        "https://reliably.com/api/entities/test-org/" "reliably.com/v1/entitycontext"
+    )
     expected_entity = EntityContext(
         metadata=EntityContextMetadata(
             labels=EntityContextExperimentLabels(title=title),
@@ -61,7 +63,9 @@ def test_create_entity_context_on_reliably_raises_exception_if_response_not_ok(
     httpx_mock: pytest_httpx._httpx_mock.HTTPXMock,
 ) -> None:
     title = "A Test Experiment Title"
-    request_url = "https://reliably.com/entities/test-org/reliably.com/v1/entitycontext"
+    request_url = (
+        "https://reliably.com/api/entities/test-org/" "reliably.com/v1/entitycontext"
+    )
     expected_entity = EntityContext(
         metadata=EntityContextMetadata(
             labels=EntityContextExperimentLabels(title=title),

--- a/tests/probes/test_get_objective_results.py
+++ b/tests/probes/test_get_objective_results.py
@@ -21,7 +21,7 @@ def test_that_get_objective_results_by_label_returns_correct_results(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/api/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=1"
     )
     httpx_mock.add_response(method="GET", url=request_url, json=results[:1])
@@ -54,7 +54,7 @@ def test_that_get_objective_results_by_label_raises_exception_if_non_200(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/api/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=1"
     )
     httpx_mock.add_response(method="GET", url=request_url, status_code=400)
@@ -89,7 +89,7 @@ def test_that_get_objective_results_by_label_passes_limit_parameter_correctly(
         ",".join([f"{key}={value}" for key, value in labels.items()])
     )
     request_url = (
-        "https://reliably.com/entities/test-org/reliably.com/v1/objectiveresult"
+        "https://reliably.com/api/entities/test-org/reliably.com/v1/objectiveresult"
         f"?objective-match={encoded_labels}&limit=20"
     )
     httpx_mock.add_response(method="GET", url=request_url, json=results)


### PR DESCRIPTION
With APIs moving behind `/api` in Reliablys load balancing, this means our base url must change

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
